### PR TITLE
sbin/make.cross: use proper gcc_arch for ARCH=riscv

### DIFF
--- a/sbin/make.cross
+++ b/sbin/make.cross
@@ -197,6 +197,9 @@ setup_crosstool()
 		openrisc)
 			gcc_arch=or1k-linux
 			;;
+		riscv)
+			gcc_arch=riscv64-linux
+			;;
 		s390)
 			gcc_arch=s390x-linux
 			;;


### PR DESCRIPTION
gcc 8.1.0 for riscv is named riscv64, so override the default gcc_arch.

Signed-off-by: Deepa Dinamani <deepa.kernel@gmail.com>