### PR TITLE
run-local: Remove '--dry-run' option from usage message

### DIFF
--- a/bin/run-local
+++ b/bin/run-local
@@ -31,7 +31,7 @@ $opt_set_key_value = {}
 options = {in_tbox: false}
 
 opt_parser = OptionParser.new do |opts|
-  opts.banner = 'Usage: run-local [--dry-run] [-o RESULT_ROOT] JOBFILE'
+  opts.banner = 'Usage: run-local [-o RESULT_ROOT] JOBFILE'
 
   opts.separator ''
   opts.separator 'options:'

--- a/bin/run-local.sh
+++ b/bin/run-local.sh
@@ -8,7 +8,7 @@ export BENCHMARK_ROOT=/lkp/benchmarks
 usage()
 {
 	cat <<EOF
-Usage: run-local [--dry-run] [-o RESULT_ROOT] JOB_SCRIPT
+Usage: run-local [-o RESULT_ROOT] JOB_SCRIPT
 
 options:
     -o  RESULT_ROOT         dir for storing all results

--- a/doc/lkp-howto.md
+++ b/doc/lkp-howto.md
@@ -241,7 +241,7 @@ Use run-local command to run a test job.
 
 ```
 	# ./bin/run-local -h
-	Usage: run-local [--dry-run] [-o RESULT_ROOT] JOBFILE
+	Usage: run-local [-o RESULT_ROOT] JOBFILE
 	...
 ```
 


### PR DESCRIPTION
'run-local' and 'run-local.sh' usage message says that they support
'--dry-run' option but they don't.  This commit fixes the usage
messages.

Signed-off-by: SeongJae Park <sj38.park@gmail.com>