### PR TITLE
stats/mpstat: update new match method

### DIFF
--- a/stats/mpstat
+++ b/stats/mpstat
@@ -30,7 +30,11 @@ def parse_time(date, line)
 end
 
 first_line = STDIN.gets
-date = /\d+-\d+-\d+/.match(first_line)
+
+date = first_line.split[3]
+date = /\d+-\d+-\d+/.match(date)
+exit 1 if date.nil?
+
 max_usage = 0
 max_record = nil
 


### PR DESCRIPTION
the previous method fails if the hostname contains 'a-b-c' like below:

~/workspace/lkp/lkp-tests$ head ../github-17/mpstat
Linux 4.9.112-32.el7.x86_64 (ip-10-22-2-38.us-west-2.compute.internal) 2018-09-18 	_x86_64_	(2 CPU)

07:31:09     CPU    %usr   %nice    %sys %iowait    %irq   %soft  %steal %guest  %gnice   %idle

Fixes: #17
Signed-off-by: Li Zhijian <zhijianx.li@intel.com>