### PR TITLE
Add dependence for sysbench to the sysbench* jobs. Fix #1.

### DIFF
--- a/distro/depends/sysbench
+++ b/distro/depends/sysbench
@@ -1,1 +1,2 @@
+sysbench
 libmariadbclient18

--- a/distro/depends/sysbench-dev
+++ b/distro/depends/sysbench-dev
@@ -1,2 +1,3 @@
+sysbench
 pkg-config
 libmariadbclient-dev


### PR DESCRIPTION
By reading the code I found both `fileio` and `sysbench-*` use `sysbench` command:
```
./lkp-tests/tests/fileio:	log_cmd sysbench --test=fileio ${args} prepare
./lkp-tests/tests/sysbench-cpu:log_cmd sysbench $args run
```

But in `depends` directory, the dependence only exist for `fileio`:
```
[root@ip-10-22-2-226 depends]# pwd
/root/lkp/lkp-tests/distro/depends
[root@ip-10-22-2-226 depends]# ll sysbench*
-rw-r--r--. 1 root root 32 Sep 26 07:41 sysbench
lrwxrwxrwx. 1 root root  8 Sep 26 07:41 sysbench-cpu -> sysbench
-rw-r--r--. 1 root root 32 Sep 26 07:41 sysbench-dev
lrwxrwxrwx. 1 root root  8 Sep 26 07:41 sysbench-memory -> sysbench
lrwxrwxrwx. 1 root root  8 Sep 26 07:41 sysbench-mutex -> sysbench
lrwxrwxrwx. 1 root root  8 Sep 26 07:41 sysbench-threads -> sysbench
[root@ip-10-22-2-226 depends]# grep sysbench *
fileio:sysbench
[root@ip-10-22-2-226 depends]# 
```

Which will cause the following issue if we execute `sysbench` cases separately:
```
[root@ip-10-22-2-38 lkp]# lkp install
[root@ip-10-22-2-38 lkp]# lkp install lkp-tests/jobs/sysbench-cpu.yaml 
[root@ip-10-22-2-38 lkp]# lkp run lkp-tests/jobs/sysbench-cpu.yaml 
2018-09-29 09:46:59 +0000 WARN -- skip non-executable /root/lkp/lkp-tests/stats/build-ceph
2018-09-29 09:47:00 sysbench --num-threads=2 --max-time=300 --test=cpu --cpu-max-prime=20000 run
/root/lkp/lkp-tests/lib/reproduce-log.sh: line 19: sysbench: command not found
[root@ip-10-22-2-38 lkp]# 
```
------
Modify the code:
```
[root@ip-10-22-2-38 lkp]# vi lkp-tests/distro/depends/sysbench-dev 
[root@ip-10-22-2-38 lkp]# vi lkp-tests/distro/depends/sysbench
[root@ip-10-22-2-38 lkp]# grep sysbench lkp-tests/distro/depends/*
lkp-tests/distro/depends/fileio:sysbench
lkp-tests/distro/depends/sysbench:sysbench
lkp-tests/distro/depends/sysbench-cpu:sysbench
lkp-tests/distro/depends/sysbench-dev:sysbench
lkp-tests/distro/depends/sysbench-memory:sysbench
lkp-tests/distro/depends/sysbench-mutex:sysbench
lkp-tests/distro/depends/sysbench-threads:sysbench
```
Verified on CentOS 7.5:
```
[root@ip-10-22-2-38 lkp]# lkp install lkp-tests/jobs/sysbench-cpu.yaml 
(will install sysbench via yum)
[root@ip-10-22-2-38 lkp]# lkp run lkp-tests/jobs/sysbench-cpu.yaml 
(no such issue)
```