### PR TITLE
Fix adaptations for libhugetlbfs on centos/fedora

### DIFF
--- a/distro/adaptation/centos
+++ b/distro/adaptation/centos
@@ -24,7 +24,7 @@ initramfs-tools: dracut
 iozone3: gnuplot*
 iproute2: iproute
 klibc-utils:
-gcc-multilib: libgcc.686
+gcc-multilib: libgcc.i686
 libacl1-dev: libacl-devel
 libaio1: libaio libaio-devel
 libaio-dev: libaio-devel
@@ -154,6 +154,7 @@ python-minimal: python2
 python-numpy: numpy
 python-numpy: numpy
 python-openssl: pyOpenSSL
+python-pkg-resources: python-setuptools
 rstatd: rusers-server
 rt-tests: numactl-devel
 ruby-dev: ruby-devel

--- a/distro/adaptation/fedora
+++ b/distro/adaptation/fedora
@@ -12,6 +12,7 @@ fsmark: fs_mark
 gcc-4.9: gcc
 gcc-5: gcc
 gcc-6: gcc
+gcc-multilib: libgcc.i686
 gfortran: gcc-gfortran
 hpcc:
 initramfs-tools: dracut
@@ -114,6 +115,7 @@ pkg-config: pkgconfig
 plzip:
 postmark:
 python-minimal: python2
+python-pkg-resources: python-setuptools
 rt-tests: numactl-devel
 ruby-dev: ruby-devel
 sg3-utils: sg3_utils


### PR DESCRIPTION
Quite sure that libgcc.686 was just a typo, forgetting the i.
Also, python-setuptools seems to suffice for the python-pkg-resources dependency on Fedora and CentOS

Signed-off-by: Johnny Bieren <jbieren@redhat.com>