### PR TITLE
make.cross: allow user to configure GCC_INSTALL_PATH

### DIFF
--- a/sbin/make.cross
+++ b/sbin/make.cross
@@ -20,7 +20,7 @@
 # Credit: Tony Breeds <tony@bakeyournoodle.com> for crosstool
 
 GCC_VERSION=${GCC_VERSION:-""}
-GCC_INSTALL_PATH="$HOME/0day"
+GCC_INSTALL_PATH=${GCC_INSTALL_PATH:-"$HOME/0day"}
 
 if [[ ! "$0" =~ 'make.cross' && "$0" =~ make\.([a-z0-9_]+) ]]; then
 	export ARCH="${BASH_REMATCH[1]}"


### PR DESCRIPTION
Users may want to install 0day tool chain into a custom location,
this patch makes sure we honor the user configuration if it's
present.

Signed-off-by: Leandro Dorileo <leandro.maciel.dorileo@intel.com>