### PR TITLE
repo/linux: update selinux mailing list, drop obsolete git repos

### DIFF
--- a/repo/linux/pcmoore-selinux
+++ b/repo/linux/pcmoore-selinux
@@ -1,6 +1,6 @@
 url: https://git.kernel.org/pub/scm/linux/kernel/git/pcmoore/selinux.git
 integration_testing_branches: next
-mail_cc: selinux@tycho.nsa.gov
+mail_cc: selinux@vger.kernel.org
 owner: Paul Moore <paul@paul-moore.com>
 subsystems:
 - selinux

--- a/repo/linux/selinux
+++ b/repo/linux/selinux
@@ -1,2 +1,0 @@
-url: git://git.infradead.org/users/eparis/selinux.git
-mail_cc: selinux@tycho.nsa.gov

--- a/repo/linux/users-pcmoore-selinux
+++ b/repo/linux/users-pcmoore-selinux
@@ -1,2 +1,0 @@
-url: git://git.infradead.org/users/pcmoore/selinux
-owner: Paul Moore <paul@paul-moore.com>


### PR DESCRIPTION
The selinux mailing list has moved to selinux@vger.kernel.org, so
update its address.  Drop two obsolete infradead git repos.

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>