### PR TITLE
repo: add build success notification for martineau

### DIFF
--- a/repo/linux/martineau
+++ b/repo/linux/martineau
@@ -1,2 +1,3 @@
 url: git://git.kernel.org/pub/scm/linux/kernel/git/martineau/linux
 owner: Mat Martineau <mathew.j.martineau@linux.intel.com>
+notify_build_success_branch: .*


### PR DESCRIPTION
Signed-off-by: Mat Martineau <mathew.j.martineau@linux.intel.com>