### PR TITLE
run-local.sh: use copy to upload files on run-local.sh

### DIFF
--- a/bin/run-local.sh
+++ b/bin/run-local.sh
@@ -43,6 +43,7 @@ else
 fi
 
 export TMP_RESULT_ROOT=$RESULT_ROOT
+export LKP_LOCAL_RUN=1
 rm -rf $TMP
 mkdir $TMP
 

--- a/lib/upload.sh
+++ b/lib/upload.sh
@@ -156,6 +156,11 @@ upload_files()
 	# NO_NETWORK is empty: means network is avaliable
 	# VM_VIRTFS is empty: means it's not a 9p fs(used by lkp-qemu)
 	if [ -z "$NO_NETWORK$VM_VIRTFS" ]; then
+		[ -z "$JOB_RESULT_ROOT" -a "$LKP_LOCAL_RUN" = "1" ] && { # bin/run-local.sh
+			upload_files_copy "$@"
+			return
+		}
+
 		if has_cmd rsync && is_local_server; then
 			upload_files_rsync "$@"
 			return


### PR DESCRIPTION
root@clear-lkp-30040~/jobs # lkp compile phoronix-test-suite-clearlinux-stress-ng-1.2.2-clear-24300-phoronix-x86_64.yaml >a.sh
root@clear-lkp-30040~/jobs # chmod +x a.sh
root@clear-lkp-30040~/jobs # lkp run -o /wtf a.sh
[...snip...]
stress-ng-1.2.2.seconds: 122.897629556
kill 21874 vmstat --timestamp -n 10
kill 21864 dmesg --follow --decode
kill 21880 vmstat --timestamp -n 1
wait for background processes: 21926 21907 21868 21898 21947 21956 21988 21904 21914 21998 21984 interrupts meminfo uptime proc-vmstat softirqs diskstats sched_debug proc-stat slabinfo mpstat turbostat
curl: (22) The requested URL returned error: 503 Service Unavailable
curl: (22) The requested URL returned error: 503 Service Unavailable

Fixes: #38
Signed-off-by: Li Zhijian <zhijianx.li@intel.com>