### PR TITLE
use Sparse's official repository on kernel.org

### DIFF
--- a/repo/sparse/sparse
+++ b/repo/sparse/sparse
@@ -1,2 +1,2 @@
-url: https://github.com/lucvoo/sparse.git
+url: git://git.kernel.org/pub/scm/devel/sparse/sparse.git
 owner: Luc Van Oostenryck <luc.vanoostenryck@gmail.com>


### PR DESCRIPTION
Currently lkp-tests uses for Sparse the semi-private repository
I have on github to share experimental branches.

Normally, I keep the master branch on this repository in sync
with the official repository on kernel.org but I think it would
be better for lkp-tests to use the official repository.

Signed-off-by: Luc Van Oostenryck <luc.vanoostenryck@gmail.com>