### PR TITLE
distro/adaptation: Adjust for renamed bsdtar package

### DIFF
--- a/distro/adaptation/debian
+++ b/distro/adaptation/debian
@@ -6,3 +6,6 @@
 
 # glarmk2 is for reason(1) above
 glmark2: 
+
+# bsdtar for reason(1) above since it has been renamed to libarchive-tools
+bsdtar: bsdtar|libarchive-tools

--- a/distro/adaptation/ubuntu
+++ b/distro/adaptation/ubuntu
@@ -1,3 +1,4 @@
+bsdtar: bsdtar|libarchive-tools
 libtool-bin:
 linux-perf: linux-tools-generic
 linux-tools: linux-tools-generic


### PR DESCRIPTION
The bsdtar binary package has been replaced with the libarchive-tools
package in recent Debian and Ubuntu releases. For some time, the bsdtar
package was a transitional package that depended on the libarchive-tools
package but now the bsdtar package has been completely removed.

The libarchive-tools package does not exist in some currently supported
older releases such as Ubuntu 16.04 LTS so a simple adaptation is not
possbile as `lkp install` will fail on those releases. Instead, make use
of apt's regex support to install "bsdtar|libarchive-tools". It installs
both packages where they both exist (this is fine) and only installs the
one that exists where the other isn't available.

Tested on Ubuntu Eoan, Ubuntu 19.10, Ubuntu 19.04 LTS, Ubuntu 18.04 LTS,
Ubuntu 16.04 LTS, Debian Sid, and Debian Buster.

Fixes: #50
Signed-off-by: Tyler Hicks <tyhicks@canonical.com>