### PR TITLE
Miscellaneous fixes for recent Debian and Ubuntu releases

### DIFF
--- a/distro/adaptation-pkg/debian
+++ b/distro/adaptation-pkg/debian
@@ -82,7 +82,10 @@ stream::
 stress-ng::
 stutter::
 swapin: vm-scalability
-sysbench::
+sysbench-cpu::
+sysbench-memory::
+sysbench-mutex::
+sysbench-threads::
 tbench::
 thrulay::
 trace-cmd::

--- a/distro/adaptation-pkg/ubuntu
+++ b/distro/adaptation-pkg/ubuntu
@@ -78,6 +78,10 @@ stream::
 stress-ng::
 stutter::
 swapin: vm-scalability
+sysbench-cpu::
+sysbench-memory::
+sysbench-mutex::
+sysbench-threads::
 tbench::
 thrulay::
 trace-cmd::

--- a/distro/adaptation/debian
+++ b/distro/adaptation/debian
@@ -15,3 +15,6 @@ btrfs-tools: btrfs-tools|btrfs-progs
 
 # libmariadbclient18 for reason(1) above since it has been renamed to libmariadb3
 libmariadbclient18: libmariadbclient18|libmariadb3
+
+# which for reason(3) above
+which: debianutils

--- a/distro/adaptation/debian
+++ b/distro/adaptation/debian
@@ -13,6 +13,9 @@ bsdtar: bsdtar|libarchive-tools
 # btrfs-tools for reason(1) above since it has been renamed to btrfs-progs
 btrfs-tools: btrfs-tools|btrfs-progs
 
+# libmariadbclient-dev for reason(1) above since mariadb_config has been moved to libmariadb-dev-compat
+libmariadbclient-dev: libmariadbclient-dev|libmariadb-dev-compat
+
 # libmariadbclient18 for reason(1) above since it has been renamed to libmariadb3
 libmariadbclient18: libmariadbclient18|libmariadb3
 

--- a/distro/adaptation/debian
+++ b/distro/adaptation/debian
@@ -9,3 +9,6 @@ glmark2:
 
 # bsdtar for reason(1) above since it has been renamed to libarchive-tools
 bsdtar: bsdtar|libarchive-tools
+
+# libmariadbclient18 for reason(1) above since it has been renamed to libmariadb3
+libmariadbclient18: libmariadbclient18|libmariadb3

--- a/distro/adaptation/debian
+++ b/distro/adaptation/debian
@@ -10,5 +10,8 @@ glmark2:
 # bsdtar for reason(1) above since it has been renamed to libarchive-tools
 bsdtar: bsdtar|libarchive-tools
 
+# btrfs-tools for reason(1) above since it has been renamed to btrfs-progs
+btrfs-tools: btrfs-tools|btrfs-progs
+
 # libmariadbclient18 for reason(1) above since it has been renamed to libmariadb3
 libmariadbclient18: libmariadbclient18|libmariadb3

--- a/distro/adaptation/ubuntu
+++ b/distro/adaptation/ubuntu
@@ -1,5 +1,6 @@
 bsdtar: bsdtar|libarchive-tools
 btrfs-tools: btrfs-tools|btrfs-progs
+libmariadbclient-dev: libmariadbclient-dev|libmariadb-dev-compat
 libmariadbclient18: libmariadbclient18|libmariadb3
 libtool-bin:
 linux-perf: linux-tools-generic

--- a/distro/adaptation/ubuntu
+++ b/distro/adaptation/ubuntu
@@ -20,3 +20,4 @@ libgflags2v5:libgflags-dev
 perl-modules-5.24:perl-modules-5.26
 libperl5.24:libperl5.26
 pmdk:pmdk-tools
+which: debianutils

--- a/distro/adaptation/ubuntu
+++ b/distro/adaptation/ubuntu
@@ -1,4 +1,5 @@
 bsdtar: bsdtar|libarchive-tools
+btrfs-tools: btrfs-tools|btrfs-progs
 libmariadbclient18: libmariadbclient18|libmariadb3
 libtool-bin:
 linux-perf: linux-tools-generic

--- a/distro/adaptation/ubuntu
+++ b/distro/adaptation/ubuntu
@@ -1,4 +1,5 @@
 bsdtar: bsdtar|libarchive-tools
+libmariadbclient18: libmariadbclient18|libmariadb3
 libtool-bin:
 linux-perf: linux-tools-generic
 linux-tools: linux-tools-generic


### PR DESCRIPTION
A set of fixes needed to run various tests on newer Debian and Ubuntu releases. Most are distro package name adaptations but one is a fix for a `makepkg` adaptation.