### PR TITLE
repo: add mail cc for martineau

### DIFF
--- a/repo/linux/martineau
+++ b/repo/linux/martineau
@@ -1,3 +1,4 @@
 url: https://git.kernel.org/pub/scm/linux/kernel/git/martineau/linux.git
 owner: Mat Martineau <mathew.j.martineau@linux.intel.com>
 notify_build_success_branch: .*
+mail_cc: mathew.j.martineau@linux.intel.com


### PR DESCRIPTION
Modify repo set up to send me build results even if I'm not the author or committer.

I haven't found documentation for the repo/linux/* file format - is there any you can share?

Is it possible to only build certain branches? Or to have multiple configurations for the same repository that email different addresses for different branches?