### PR TITLE
repo/linux/mptcp: Only build export branch

### DIFF
--- a/repo/linux/mptcp
+++ b/repo/linux/mptcp
@@ -1,5 +1,7 @@
 url: https://github.com/multipath-tcp/mptcp_net-next.git
 integration_testing_branches: export
+whitelist_branch: export
+blacklist_branch: .*
 mail_cc:
 - mptcp@lists.01.org
 owner: Mat Martineau <mathew.j.martineau@linux.intel.com>


### PR DESCRIPTION
Signed-off-by: Mat Martineau <mathew.j.martineau@linux.intel.com>