### PR TITLE
repo/linux/android-common: No longer cc groeck@ directly

### DIFF
--- a/repo/linux/android-common
+++ b/repo/linux/android-common
@@ -2,6 +2,5 @@ url: https://android.googlesource.com/kernel/common
 belongs_to: chrome-os
 notify_build_success_branch: .*
 mail_to: cros-kernel-buildreports@googlegroups.com
-mail_cc: Guenter Roeck <groeck@google.com>
 test_old_branches: .*
 blacklist_branch: .*-release|.*-mr.*


### PR DESCRIPTION
I can get all reports through the mailing list and don't need to be copied
directly.

Signed-off-by: Guenter Roeck <groeck@chromium.org>