### PR TITLE
repo/linux/mptcp: Turn off build success notification

### DIFF
--- a/repo/linux/mptcp
+++ b/repo/linux/mptcp
@@ -2,7 +2,6 @@ url: https://github.com/multipath-tcp/mptcp_net-next.git
 integration_testing_branches: export
 whitelist_branch: export
 blacklist_branch: .*
-notify_build_success_branch: export
 mail_cc:
 - mptcp@lists.01.org
 owner:


### PR DESCRIPTION
We've confirmed that our build configuration is working for the expected branch, so we don't need the success email any more.

Signed-off-by: Mat Martineau <mathew.j.martineau@linux.intel.com>