### PR TITLE
repo/linux: Update derkling's repos

### DIFF
--- a/repo/linux/derkling
+++ b/repo/linux/derkling
@@ -1,1 +1,4 @@
-url: derkling	https://github.com/derkling/linux
+url: git://github.com/derkling/linux.git
+owner: Patrick Bellasi <patrick.bellasi@matbug.net>
+notify_build_success_branch: .*
+

--- a/repo/linux/linux-pb
+++ b/repo/linux/linux-pb
@@ -1,4 +1,0 @@
-url: git://linux-arm.org/linux-pb.git
-notify_build_success_branch: .*
-owner: Patrick Bellasi <patrick.bellasi@matbug.net>
-


### PR DESCRIPTION
I do not have anymore access to the linux-pb repo, let's remove it.
Update also info related to my other github based repo.

Cc: Philip Li <philip.li@intel.com>
Cc: Dietmar Eggemann <dietmar.eggemann@arm.com>
Signed-off-by: Patrick Bellasi <patrick.bellasi@matbug.net>