### PR TITLE
mpstat: eliminate 'No such process' message

### DIFF
--- a/distro/depends/mpstat
+++ b/distro/depends/mpstat
@@ -1,1 +1,2 @@
 sysstat
+procps-ng

--- a/monitors/mpstat
+++ b/monitors/mpstat
@@ -37,4 +37,4 @@ pid=$!
 
 $WAIT_POST_TEST_CMD
 
-kill -INT "$pid"
+pkill -INT "$pid"


### PR DESCRIPTION
Use pkill instead of kill to eliminate 'No such process' message if the
process has already been killed.

Signed-off-by: Hao Li <lihao2018.fnst@cn.fujitsu.com>