### PR TITLE
distro/adaptation: add libarchive to fedora and archlinux

### DIFF
--- a/distro/adaptation/archlinux
+++ b/distro/adaptation/archlinux
@@ -12,6 +12,7 @@ freeglut3: freeglut
 initramfs-tools: mkinitcpio
 iozone3: iozone
 klibc-utils:
+libarchive13: libarchive
 libacl1-dev: acl
 libaio1: libaio
 libaio-dev: libaio

--- a/distro/adaptation/fedora
+++ b/distro/adaptation/fedora
@@ -23,6 +23,7 @@ klibc-utils:
 libacl1-dev: libacl-devel
 libaio1: libaio
 libaio-dev: libaio-devel
+libarchive13: libarchive
 libarchive-dev: libarchive-devel
 libattr1: libattr
 libattr1-dev: libattr-devel


### PR DESCRIPTION
The libarchive13 package is named libarchive on fedora and archlinux

Signed-off-by: Hao Li <lihao2018.fnst@cn.fujitsu.com>