### PR TITLE
Archlinux: yay won't reinstall updated pkgs anymore

### DIFF
--- a/distro/installer/archlinux
+++ b/distro/installer/archlinux
@@ -11,4 +11,4 @@
 # Use regular user to do this
 regular_user=`grep 1000 /etc/passwd | awk -F':' '{ print $1 }'`
 
-sudo -u $regular_user yay -S --noconfirm $*
+sudo -u $regular_user yay -S --noconfirm --needed $*

--- a/lib/install.sh
+++ b/lib/install.sh
@@ -17,7 +17,7 @@ sync_distro_sources()
 			yum update
 		fi ;;
 	redhat) yum update ;;
-	archlinux) yay -Sy ;;
+	archlinux) yay -Sy --needed;;
 	opensuse)
 		zypper update ;;
 	oracle) yum update ;;


### PR DESCRIPTION
`yay  -Sy <pkg>` reinstalls  `<pkg>` if already present and updated, the flag `--needed` will prevent useless operations.