### PR TITLE
Debian and Ubuntu adaptation fix

### DIFF
--- a/distro/adaptation/debian
+++ b/distro/adaptation/debian
@@ -10,6 +10,7 @@ fsverity:
 
 # reason(3)
 which: debianutils
+bsdtar: libarchive-tools
 libgcrypt-dev: libgcrypt11-dev
 libipsec-mb:
 libicu: libicu57

--- a/distro/adaptation/ubuntu
+++ b/distro/adaptation/ubuntu
@@ -1,3 +1,11 @@
+# this adaptation is used for
+# 1. not exist/valid packages, mark it empty to avoid installing error.
+# 2. exist/valid packages, mark it empty if you don't want to install later.
+# 3. exist/valid packages, but its name needs to be adapted for other distro,
+#    mapping to a new package name, then the new package will be install later.
+
+which: debianutils
+bsdtar: libarchive-tools
 iblz4-1:liblz4-dev
 libbz2-1.0:libbz2-dev
 libcpupower-dev:
@@ -20,5 +28,4 @@ linux-perf: linux-tools-generic
 linux-tools: linux-tools-generic
 perl-modules-5: perl-modules-5.26
 pmdk:pmdk-tools
-which: debianutils
 zlib1g:zlib1g-dev

--- a/distro/adaptation/ubuntu
+++ b/distro/adaptation/ubuntu
@@ -28,4 +28,5 @@ linux-perf: linux-tools-generic
 linux-tools: linux-tools-generic
 perl-modules-5: perl-modules-5.26
 pmdk:pmdk-tools
+procps-ng: procps
 zlib1g:zlib1g-dev


### PR DESCRIPTION
The `distro/adaptation/{debian,ubuntu}` files are updated to avoid installation problem.
**Both:**
- added `bsdtar: libarchive-tools`;

**Ubuntu:**
- add docs-comment at top;
- add `procps-ng: procps`
