### PR TITLE
distro/adaptation/ubuntu: Add libmariadb3 

### DIFF
--- a/distro/adaptation/ubuntu
+++ b/distro/adaptation/ubuntu
@@ -16,6 +16,7 @@ libhugetlbfs-bin: hugepages
 libhugetlbfs: libhugetlbfs0
 libicu: libicu-dev
 libipsec-mb:
+libmariadbclient18: libmariadb3
 libntfs: libntfs-3g88
 libperl5: libperl5.26
 libsnappy1v5:libsnappy-dev


### PR DESCRIPTION
libmariadbclient18 package is now referred to the current&correct package libmariadb3