### PR TITLE
add new testcase s-bandwidth

### DIFF
--- a/distro/adaptation-pkg/ubuntu
+++ b/distro/adaptation-pkg/ubuntu
@@ -114,3 +114,4 @@ vmem::
 phoronix-test-suite::
 kernbench::
 rt-app::
+s-bandwidth::

--- a/jobs/s-bandwidth.yaml
+++ b/jobs/s-bandwidth.yaml
@@ -1,6 +1,8 @@
 suite: s-bandwidth
 testcase: s-bandwidth
 category: benchmark
+fs: ext4
+disk: 1HDD
 
 s-bandwidth:
   duration:

--- a/jobs/s-bandwidth.yaml
+++ b/jobs/s-bandwidth.yaml
@@ -1,0 +1,21 @@
+suite: s-bandwidth
+testcase: s-bandwidth
+category: benchmark
+
+s-bandwidth:
+  duration:
+  - 10
+  - 60
+  - 120
+  - 300
+  - 600
+  block_size:
+  - 100k
+  - 100m
+  - 300m
+  - 500m
+  type:
+  - read
+  - write
+  - randread
+  - randwrite

--- a/pkg/s-bandwidth/PKGBUILD
+++ b/pkg/s-bandwidth/PKGBUILD
@@ -1,0 +1,15 @@
+# vim:set ts=2 sw=2 et filetype=sh:
+pkgname=s-bandwidth
+pkgver=git
+pkgrel=1
+pkgdesc="Small collection of benchmarks for storage I/O"
+arch=('any')
+license=('GPL2')
+source=($pkgname::'https://github.com/Algodev-github/S.git')
+md5sums=('SKIP')
+
+package() {
+    local install_prefix=$pkgdir/lkp/benchmarks/$pkgname
+    mkdir -p "$install_prefix"
+    cp -r "$srcdir/$pkgname/"* "$install_prefix"
+}

--- a/stats/s-bandwidth
+++ b/stats/s-bandwidth
@@ -5,9 +5,14 @@ require "#{LKP_SRC}/lib/statistics"
 
 workload = 0
 data = false
+# Capture the seven floating point variables, that are written right after
+# each line that starts with "Device", like the example below
+
+# Device tps MB_read/s MB_wrtn/s MB_dscd/s MB_read MB_wrtn MB_dscd
+# nvme0n1 3366.00 136.23 0.03 0.00 3408 0 0
 pattern = /^\S*\s+(\d*\.?\d+)\s+(\d*\.?\d+)\s+(\d*\.?\d+)\s+(\d*\.?\d+)\s+(\d*\.?\d+)\s+(\d*\.?\d+)\s+(\d*\.?\d+)\s+/
 while (line = STDIN.gets)
-  if [data]
+  if data
     if line.match(pattern)
       puts 'tps: ' + $1
       puts 'MB_read/s: ' + $2

--- a/stats/s-bandwidth
+++ b/stats/s-bandwidth
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+LKP_SRC = ENV['LKP_SRC'] || File.dirname(File.dirname(File.realpath($PROGRAM_NAME)))
+
+require "#{LKP_SRC}/lib/statistics"
+
+workload = 0
+data = false
+pattern = /^\S*\s+(\d*\.?\d+)\s+(\d*\.?\d+)\s+(\d*\.?\d+)\s+(\d*\.?\d+)\s+(\d*\.?\d+)\s+(\d*\.?\d+)\s+(\d*\.?\d+)\s+/
+while (line = STDIN.gets)
+  if [data]
+    if line.match(pattern)
+      puts 'tps: ' + $1
+      puts 'MB_read/s: ' + $2
+      puts 'MB_wrtn/s: ' + $3
+      puts 'MB_dscd/s: ' + $4
+      puts 'MB_read: ' + $5
+      puts 'MB_wrtn: ' + $6
+      puts 'MB_dscd: ' + $7
+    end
+    data = false
+  else
+    if line.match(/^Device.*$/)
+      data = true
+    end
+  end
+end

--- a/tests/s-bandwidth
+++ b/tests/s-bandwidth
@@ -1,0 +1,24 @@
+#!/bin/sh
+# - duration
+# - block_size
+# - type
+
+# test from the S suite bandwidth_latency.sh
+# Measures bandwidth and latency enjoyed by processes competing for a
+# storage devices, with and without I/O control.
+
+# exmaple usage
+# sudo ./bandwidth-latency.sh -d 5 -Z 100m -T randread
+
+. $LKP_SRC/lib/env.sh
+. $LKP_SRC/lib/debug.sh
+. $LKP_SRC/lib/reproduce-log.sh
+
+cd $BENCHMARK_ROOT/${testcase}/bandwidth-latency/ || \
+  die "no $BENCHMARK_ROOT/${testcase}/bandwidth_latency"
+
+[ -n "$duration" ] && opt_dur=" -d $duration "
+[ -n "$block_size" ] && opt_block=" -z $block_size "
+[ -n "$type" ] && opt_type=" -T $type "
+
+log_cmd ./bandwidth-latency.sh $opt_dur $opt_block $opt_type


### PR DESCRIPTION
The purpose of this patch is only to show how to add a new testcase to lkp.
In order to do that, add all the required scripts to run a simple testcase.

The testcase (`bandwisth-latency.sh`) is taken from the S suite, which consist
of a small collection of scripts aimed at testing the machine performance under
different I/O situations.
`bandwidth_latency` measures bandwidth and latency enjoyed by processes
competing for a storage device, with and without I/O control.
Given the fact that nontrivial work would be required to make this test
actually usable, this patch implements in the most basic way all the components
required for adding any arbitrary test to lkp, in order to demonstrate how to do
that without providing an unnecessary full implementation for this specific test.

distro/adaptation-pkg/ubuntu: add s-bandwidth

In order to install a new testcase, lkp needs a package definition to know
if the tescase needs an adaptation or not under the current distro.
Add definition for s-bandwidth to use the package itself under ubuntu.

jobs: add jobs/s-bandwidth.yaml

A list of all input parameters and values to run the tescase with must be
supplied to lkp, the actual values used will be selected when running a split job file.
The user can add all the desired parameters and associated values by following the
syntax of the example yaml file shown below.

-duration: 10s, 60s, 120s
-block_size: 100k, 100m, 500m
-type: read, write, randread, randwrite

tests: add tests/s-bandwidth

This is the actual script that runs the testcase with the parameters configured
in the job file.
Move to the correct subfolder and execute the script with the selected values,
as shown in the log the test runs as expected.

-----
fede@MSI:/lkp/result/s-bandwidth/100m-10-randread/MSI/ubuntu/defconfig/gcc-10
/5.8.0-43-generic/1$ head -32 s-bandwidth | tail -13
02/15/21 17:38:49
Device             tps    MB_read/s    MB_wrtn/s    MB_dscd/s    MB_read    MB_wrtn    MB_dscd
nvme0n1        3518.67      1142.61         0.07         0.00       3427          0          0

02/15/21 17:38:52
Device             tps    MB_read/s    MB_wrtn/s    MB_dscd/s    MB_read    MB_wrtn    MB_dscd
nvme0n1        3531.00      1123.41         0.87         0.00       3370          2          0

02/15/21 17:38:55
Device             tps    MB_read/s    MB_wrtn/s    MB_dscd/s    MB_read    MB_wrtn    MB_dscd
nvme0n1        3366.00      1136.23         0.03         0.00       3408          0          0
-----

stats: add s-bandwidth stats filter

To capture the data generated, add a stats filter script which takes only the
important part of the output and prints that on stdout as `key: value` pairs
Captured values are:
tps, MB_read/s, MB_wrtn/s, MB_dscd/s, MB_read, MB_wrtn, MB_dscd
and organized by the framework in a .json as shown below

-----
fede@MSI:/lkp/result/s-bandwidth/100m-10-randread/MSI/ubuntu/defconfig/gcc-10
/5.8.0-43-generic/1$ head -n 13 s-bandwidth.json
{
  "s-bandwidth.tps": [
    129.05,
    2995.67,
    3518.67,
    3531.0,
    3366.0,
    3391.67
  ],
  "s-bandwidth.MB_read/s": [
    8.85,
    990.98,
    1142.61,
-----

pkg/s-bandwidth: add s-bandwidth PKGBUILD file

In order to retrieve the testcase package, lkp needs a script containing all the
informations on where to retrieve the scripts and how to install it properly.

Since the S suite does not need a build and the dependencies are collected
automatically by S itself, add a single method to move all the files in
the destination directory.

Signed-off-by: Federico Gelmetti <federico.gelmo@gmail.com>