### PR TITLE
repo/linux/mptcp: Remove old mailing list

### DIFF
--- a/repo/linux/mptcp
+++ b/repo/linux/mptcp
@@ -3,7 +3,6 @@ integration_testing_branches: export
 branch_allowlist: export
 branch_denylist: .*
 mail_cc:
-- mptcp@lists.01.org
 - mptcp@lists.linux.dev
 owner:
 - Mat Martineau <mathew.j.martineau@linux.intel.com>


### PR DESCRIPTION
MPTCP development has moved completely to mptcp@lists.linux.dev, so
don't email the old lists.01.org address any more.

Signed-off-by: Mat Martineau <mathew.j.martineau@linux.intel.com>