### PR TITLE
mpstat: Fix wrong usage of pkill

### DIFF
--- a/monitors/mpstat
+++ b/monitors/mpstat
@@ -37,4 +37,4 @@ pid=$!
 
 $WAIT_POST_TEST_CMD
 
-pkill -INT "$pid"
+pkill -INT mpstat


### PR DESCRIPTION
pkill follows "pattern" rather than "pid"

Fixes: 12863b154533779e575f3d25cf56fc37e027a5ac