### PR TITLE
Write nr_cpu in bin/setup-local

### DIFF
--- a/bin/setup-local
+++ b/bin/setup-local
@@ -90,10 +90,12 @@ def create_host_config
     mem_kb = File.open('/proc/meminfo').gets.split[1].to_i
     mem_gb = mem_kb >> 20
     mem_gb = (mem_gb + 3) & 0xfffffffc
+    nr_cpu = `getconf _NPROCESSORS_CONF`
     File.open(host_config, 'w') do |file|
       file.puts "memory: #{mem_gb}G"
       file.puts "hdd_partitions: #{$opt_hdd.join ' '}"
       file.puts "ssd_partitions: #{$opt_ssd.join ' '}"
+      file.puts "nr_cpu: #{nr_cpu}"
     end
   end
   host_group_config = LKP_SRC + "/hosts/#{tbox_group(HOSTNAME)}"


### PR DESCRIPTION
Without nr_cpu in host file, I get this error
"unknown hash key: 'nr_cpu' hash"

Signed-off-by: Yihao Wu <wuyihao@linux.alibaba.com>