### PR TITLE
Fix cpuidle state name with space

### DIFF
--- a/monitors/cpuidle
+++ b/monitors/cpuidle
@@ -11,7 +11,7 @@ take_snapshot()
 	do
 		cpu=${dir#/sys/devices/system/cpu/}
 		cpu=${cpu%%/*}
-		read state_name  < $dir/name
+		cat $dir/name | sed 's/ /-/g' | read state_name
 		read state_time  < $dir/time
 		read state_usage < $dir/usage
 		echo $cpu.${state_name}.time: ${state_time}


### PR DESCRIPTION
cpuidle state name is not guaranteed spaceless,
eg "haltpoll idle". This lead to furthur issues.

Signed-off-by: Yihao Wu <wuyihao@linux.alibaba.com>