### PR TITLE
lmbench3: fix lmbench3 always return the first result

### DIFF
--- a/tests/lmbench3
+++ b/tests/lmbench3
@@ -186,6 +186,8 @@ cd $BENCHMARK_ROOT/lmbench3 || {
 }
 
 make 2>&1 || die "failed to build lmbench3"
+os=$(cd $BENCHMARK_ROOT/lmbench3/scripts; ./os)
+[ -n "$os" ] && rm -rf $BENCHMARK_ROOT/lmbench3/results/$os/
 
 case "$mode" in
 	'all') run_lmbench3_all ;;


### PR DESCRIPTION
Suppose we have
/lkp/benchmarks/lmbench3/results/x86_64-linux-gnu/myhostname.0
..
/lkp/benchmarks/lmbench3/results/x86_64-linux-gnu/myhostname.9

Currently lkp always use myhostname.0 as the result file.
Fix this by removing the unneeded lmbench files, these files
are already duplicated by lkp anyway.

Signed-off-by: Yihao Wu <wuyihao@linux.alibaba.com>