### PR TITLE
repo/linux: Update URL for ragnatech

### DIFF
--- a/repo/linux/ragnatech
+++ b/repo/linux/ragnatech
@@ -1,3 +1,3 @@
-url: git://git.ragnatech.se/linux
+url: https://git.kernel.org/pub/scm/linux/kernel/git/niklas/linux.git
 owner: Niklas Söderlund <niklas.soderlund@ragnatech.se>
 notify_build_success_branch: .*


### PR DESCRIPTION
I'm moving my tree to kernel.org.

Signed-off-by: Niklas Söderlund <niklas.soderlund@ragnatech.se>