### PR TITLE
repo/linux/chrome-os: Add chromeos-5.15

### DIFF
--- a/repo/linux/chrome-os
+++ b/repo/linux/chrome-os
@@ -1,7 +1,7 @@
 url: https://chromium.googlesource.com/chromiumos/third_party/kernel
 belongs_to: chrome-os
 randconfig_allowlist: ^(arm|arm64|i386|x86_64)
-branch_allowlist: chromeos-4.4|chromeos-4.14|chromeos-4.19|chromeos-5.4|chromeos-5.10
+branch_allowlist: chromeos-4.4|chromeos-4.14|chromeos-4.19|chromeos-5.4|chromeos-5.10|chromeos-5.15
 branch_denylist: .*
 customconfig: customconfig
 notify_build_success_branch: .*


### PR DESCRIPTION
Add chromeos-5.15 to list of branches to test.

Signed-off-by: Guenter Roeck <groeck@chromium.org>