### PR TITLE
repo/linux/mptcp: Fewer email notifications

### DIFF
--- a/repo/linux/mptcp
+++ b/repo/linux/mptcp
@@ -9,4 +9,3 @@ owner:
 - Matthieu Baerts <matthieu.baerts@tessares.net>
 subsystems:
 - mptcp
-notify_build_success_branch: .*


### PR DESCRIPTION
Build success messages don't need to be sent to the mailing list.

Signed-off-by: Mat Martineau <mathew.j.martineau@linux.intel.com>

----
Is there a way to send build success notifications only to the listed owners and not the mail_cc list, but still send the failures to all?

Just trying to reduce traffic to the mptcp mailing list.