### PR TITLE
[GIT PULL] repo/linux/ammarfaizi2-block: Update mail_cc

### DIFF
--- a/repo/linux/ammarfaizi2-block
+++ b/repo/linux/ammarfaizi2-block
@@ -1,4 +1,4 @@
 url: https://github.com/ammarfaizi2/linux-block
 notify_build_success_branch: testing/.*
 owner: Ammar Faizi <ammarfaizi2@gnuweeb.org>
-mail_cc: GNU/Weeb Mailing List <gwml@gnuweeb.org>
+mail_cc: GNU/Weeb Mailing List <gwml@vger.gnuweeb.org>


### PR DESCRIPTION
```
Hello,

Please pull one commit for ammarfaizi2-block.

Thanks!

repo/linux/ammarfaizi2-block: Update mail_cc

Viro reports that email to GNU/Weeb mailing list returned this
response:
"""
This is the mail system at host gnuweeb.org.

I'm sorry to have to inform you that your message could not
be delivered to one or more recipients. It's attached below.

For further assistance, please send mail to postmaster.

If you do so, please include this problem report. You can
delete your own text from the attached returned message.

                   The mail system

<ml@gnuweeb.org> (expanded from <gwml@gnuweeb.org>): host
    gnuweeb.org[private/dovecot-lmtp] said: 550 5.1.1 <ml@gnuweeb.org> User
    doesn't exist: ml@gnuweeb.org (in reply to RCPT TO command)
"""

The cause is the mailing list address has recently changed. Fix it.

Reported-by: Alviro Iskandar Setiawan <alviro@gnuweeb.org>
Signed-off-by: Ammar Faizi <ammarfaizi2@gnuweeb.org>
----------------------------------------------------------------
The following changes since commit 5e03b6f288fedebe386f13fcc0def583cc42908c:

  jobs/phoronix-test-suite: temporarily comment out the failed tests (2022-02-01 22:21:58 +0800)

are available in the Git repository at:

  git://github.com/ammarfaizi2/lkp-tests.git tags/ammarfaizi2-block-20220202

for you to fetch changes up to f435fb7e091c4b29ec5b09361f533a2d7d8ae06c:

  repo/linux/ammarfaizi2-block: Update mail_cc (2022-02-02 18:16:39 +0700)

----------------------------------------------------------------
ammarfaizi2-block-20220202

----------------------------------------------------------------
Ammar Faizi (1):
      repo/linux/ammarfaizi2-block: Update mail_cc

 repo/linux/ammarfaizi2-block | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

-- 
Ammar Faizi
```