### PR TITLE
repo/linux/mptcp: Also build & test the export-net branch

### DIFF
--- a/repo/linux/mptcp
+++ b/repo/linux/mptcp
@@ -1,6 +1,8 @@
 url: https://github.com/multipath-tcp/mptcp_net-next.git
-integration_testing_branches: export
-branch_allowlist: export
+integration_testing_branches:
+- export
+- export-net
+branch_allowlist: export|export-net
 branch_denylist: .*
 mail_cc:
 - mptcp@lists.linux.dev


### PR DESCRIPTION
This repository has a new branch for changes based on the net/master
branch, which also needs to be built & tested.

Signed-off-by: Mat Martineau <mathew.j.martineau@linux.intel.com>