### PR TITLE
[GIT PULL] repo/linux/ammarfaizi2-block: Don't test Android branches

### DIFF
--- a/repo/linux/ammarfaizi2-block
+++ b/repo/linux/ammarfaizi2-block
@@ -2,3 +2,5 @@ url: https://github.com/ammarfaizi2/linux-block
 notify_build_success_branch: testing/.*
 owner: Ammar Faizi <ammarfaizi2@gnuweeb.org>
 mail_cc: GNU/Weeb Mailing List <gwml@vger.gnuweeb.org>
+mail_to: Ammar Faizi <ammarfaizi2@gnuweeb.org>
+private_report_branch: google/android/.*


### PR DESCRIPTION
Hello,

Please pull 1 commit for ammarfaizi2-block to exclude Android branches from testing:
  - Don't test Android branches. These branches are not for upstream. Make the build error private.

Ref: https://lore.kernel.org/lkml/87pmlzbyff.wl-maz@kernel.org

```
The following changes since commit b9a3e6c4ca5b236e393916821e92b807d7b947e0:

  pkg/hackbench/PKGBUILD: update pkgver to 2.3 (2022-04-01 12:56:54 +0800)

are available in the Git repository at:

  https://github.com/ammarfaizi2/lkp-tests.git tags/ammarfaizi2-block-20220402

for you to fetch changes up to 60471b2072ddf13338a7cc17927ce6606675c53f:

  repo/linux/ammarfaizi2-block: Don't test Android branches (2022-04-02 17:26:19 +0700)

----------------------------------------------------------------
ammarfaizi2-block-20220402

----------------------------------------------------------------
Ammar Faizi (1):
      repo/linux/ammarfaizi2-block: Don't test Android branches

 repo/linux/ammarfaizi2-block | 2 ++
 1 file changed, 2 insertions(+)

```
