### PR TITLE
repo/linux: add mail_to for chrome-platform

### DIFF
--- a/repo/linux/chrome-platform
+++ b/repo/linux/chrome-platform
@@ -2,3 +2,4 @@ url: https://git.kernel.org/pub/scm/linux/kernel/git/chrome-platform/linux.git
 git_am_branch: for-next
 integration_testing_branches: for-next
 owner: Benson Leung <bleung@chromium.org>
+mail_to: Chrome Platform Group <chrome-platform@lists.linux.dev>


### PR DESCRIPTION
Add mail_to to Chrome Platform Group for chrome-platform.

Signed-off-by: Tzung-Bi Shih <tzungbi@kernel.org>