### PR TITLE
repo/linux: update tzungbi-chrome-platform again

### DIFF
--- a/repo/linux/tzungbi-chrome-platform
+++ b/repo/linux/tzungbi-chrome-platform
@@ -1,4 +1,5 @@
 url: https://git.kernel.org/pub/scm/linux/kernel/git/tzungbi/chrome-platform.git
 owner: Tzung-Bi Shih <tzungbi@kernel.org>
-mail_cc: Tzung-Bi Shih <tzungbi@kernel.org>
+mail_to: Tzung-Bi Shih <tzungbi@kernel.org>
 notify_build_success_branch: .*
+private_report_branch: .*


### PR DESCRIPTION
Update the config again so that it won't send build regression report to public.

Signed-off-by: Tzung-Bi Shih <tzungbi@kernel.org>