### PR TITLE
Enable blktests nvme over rdma

### DIFF
--- a/jobs/blktests-nvme.yaml
+++ b/jobs/blktests-nvme.yaml
@@ -9,3 +9,11 @@ blktests:
     - nvme-group-01
     - nvme-group-02
     - nvme-032
+
+---
+blktests:
+  test:
+    - nvme-group-01
+    - nvme-group-02
+    - nvme-032
+  nvme_trtype: rdma

--- a/jobs/blktests-nvme.yaml
+++ b/jobs/blktests-nvme.yaml
@@ -17,3 +17,6 @@ blktests:
     - nvme-group-02
     - nvme-032
   nvme_trtype: rdma
+  use_siw:
+    - true
+    - false

--- a/tests/blktests
+++ b/tests/blktests
@@ -1,6 +1,7 @@
 #!/bin/sh
 # - test
 # - nvme_trtype
+# - use_siw
 
 ## blktests is a test framework for the Linux kernel block layer and storage stack.
 
@@ -44,6 +45,7 @@ set_env()
 	fi
 
 	[ "$nvme_trtype" ] && echo "nvme_trtype=$nvme_trtype" >> config
+	[ "$use_siw" = "true" ] && echo "use_siw=1" >> config
 
 	# fix the issue: losetup: cannot find an unused loop device
 	lsmod | grep -q loop || modprobe loop

--- a/tests/blktests
+++ b/tests/blktests
@@ -1,5 +1,6 @@
 #!/bin/sh
 # - test
+# - nvme_trtype
 
 ## blktests is a test framework for the Linux kernel block layer and storage stack.
 
@@ -41,6 +42,8 @@ set_env()
 		echo "TEST_DEVS=$partition" > config
 		[ "$test" = "nvme-group1" ] && log_cmd mkdir -p /mnt/$test && log_cmd mount $partition /mnt/$test
 	fi
+
+	[ "$nvme_trtype" ] && echo "nvme_trtype=$nvme_trtype" >> config
 
 	# fix the issue: losetup: cannot find an unused loop device
 	lsmod | grep -q loop || modprobe loop


### PR DESCRIPTION
blktests support nvme over rdma natively, this PR is trying to enable it.

https://github.com/osandov/blktests/blob/master/Documentation/running-tests.md#running-nvme-rdma-nvmeof-mp-srp-tests