### PR TITLE
Fix hackbench install

### DIFF
--- a/distro/adaptation/centos
+++ b/distro/adaptation/centos
@@ -227,3 +227,4 @@ libicu: libicu57
 libgdbm-dev: gdbm-devel
 xsltproc: libxslt
 nasm: nasm.x86_64
+libpython2.7: python2-libs

--- a/distro/adaptation/fedora
+++ b/distro/adaptation/fedora
@@ -208,6 +208,6 @@ libmariadbclient18: mariadb-connector-c
 python-dev: python3-devel
 python3-dev: python3-devel
 systemtap-sdt-dev: systemtap-sdt-devel
-libpython2.7: python27
+libpython2.7: python2-libs
 python-gi:
 python-gi-cairo:

--- a/distro/adaptation/ubuntu-22.04
+++ b/distro/adaptation/ubuntu-22.04
@@ -1,0 +1,1 @@
+python: python-is-python3

--- a/pkg/hackbench/PKGBUILD
+++ b/pkg/hackbench/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=hackbench
-pkgver=2.3
+pkgver=2.4
 pkgrel=1
 arch=('i386' 'x86_64')
 url="https://www.kernel.org/pub/linux/utils/rt-tests"

--- a/pkg/rt-tests/PKGBUILD
+++ b/pkg/rt-tests/PKGBUILD
@@ -1,12 +1,12 @@
 pkgname=rt-tests
-pkgver=2.1
+pkgver=2.4
 pkgrel=0
 pkgdesc="Suite of real-time tests - cyclictest, hwlatdetect, pip_stress, pi_stress, pmqtest, ptsematest, rt-migrate-test, sendme, signaltest, sigwaittest, svsematest"
 arch=('i386' 'x86_64')
 url="https://git.kernel.org/cgit/utils/rt-tests/rt-tests.git/"
 license=('GPL')
 source=("https://www.kernel.org/pub/linux/utils/rt-tests/rt-tests-$pkgver.tar.gz")
-md5sums=('6d3d5b5f07bbb306b1158a47228906ec')
+md5sums=('5b88a361399d27520be9e39d536720c9')
 
 build() {
         cd "$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
1. Update rt-tests version.
2. This commit fixes hackbench install on:
   adopting to right python libs package on rhel/centos/fedora
   ubuntu 22-04: updating to right python package adoption

Signed-off-by: Srikanth Aithal <srikanth.aithal@amd.com>