### PR TITLE
Fix RISC-V Debian/Ubuntu dependencies install

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  riscv64-linux
   x86_64-linux
 
 DEPENDENCIES

--- a/distro/debian
+++ b/distro/debian
@@ -187,9 +187,10 @@ distro_install_depends()
 	local script
 	local bm="$1"
 	local scripts=$(find $LKP_SRC/distro/depends/ -name "$bm" -o -name "${bm}.[0-9]")
+	local arch=$(get_system_arch)
 
 	export DEBIAN_FRONTEND=noninteractive
-	add_i386_package
+	[ "$arch" = "x86_64" ] && add_i386_package
 	update
 
 	apt-get install -yf

--- a/distro/depends/lkp-dev
+++ b/distro/depends/lkp-dev
@@ -17,9 +17,9 @@ cpio
 wget
 libklibc-dev
 linux-libc-dev
-linux-libc-dev:i386
+linux-libc-dev:i386 (x86_64)
 libc6-dev
-libc6-dev:i386
+libc6-dev:i386 (x86_64)
 ruby
 ruby-dev
 bzip2
@@ -29,4 +29,4 @@ flex
 bison
 libssl-dev
 libipc-run-perl
-libc6-dev-x32
+libc6-dev-x32 (x86_64)

--- a/distro/installer/debian
+++ b/distro/installer/debian
@@ -1,8 +1,11 @@
 #!/bin/sh
 
+. $LKP_SRC/lib/detect-system.sh
+arch=$(get_system_arch)
+
 # Debian package installation
 export DEBIAN_FRONTEND=noninteractive
-dpkg --add-architecture i386 && apt-get update
+[ "$arch" = "x86_64" ] && dpkg --add-architecture i386 && apt-get update
 apt-get -o Dpkg::Options::="--force-confdef" \
      -o Dpkg::Options::="--force-confold" \
      -y install $* >/tmp/apt-get_info 2>&1

--- a/distro/installer/ubuntu
+++ b/distro/installer/ubuntu
@@ -1,8 +1,10 @@
 #!/bin/sh
 
-# enable i386 arch packages
-dpkg --add-architecture i386 && apt-get update
+. $LKP_SRC/lib/detect-system.sh
+arch=$(get_system_arch)
 
+# enable i386 arch packages
+[ "$arch" = "x86_64" ] && dpkg --add-architecture i386 && apt-get update
 apt-get -o Dpkg::Options::="--force-confdef" \
      -o Dpkg::Options::="--force-confold" \
      -o Dpkg::Options::="--force-overwrite" \


### PR DESCRIPTION
Not add i386 arch on Debian/Ubuntu RISC-V port, otherwise it will cause
apt update fails every time.

Mark amd64/i386 arch only packages so the existing package filtering code
can work, these packages do not exist on RISC-V port.

Signed-off-by: Xin Zhang <xin.x.zhang@intel.com>

---

Hello maintainers,

- This patch is tested on SiFive HiFive Unmatched board running Ubuntu 22.04 RISC-V port. Debian sid RISC-V port should be mostly the same.
- Both Ubuntu 22.04 and Debian sid RISC-V port don't have ruby2 so I'm using rbenv to install ruby 2.7.6 globally.
- This patch is for fixing `sudo lkp install`.
- For each testcase there may be more dependency package changes, we may add them case by case later.
- It seems `distro/installer/$distro` and `distro/$distro` have duplicated install logic and the latter not used in `lkp install`, but modified both anyway.