### PR TITLE
update libunwind version for ubuntu22.04

### DIFF
--- a/distro/adaptation/ubuntu-22.04
+++ b/distro/adaptation/ubuntu-22.04
@@ -1,1 +1,3 @@
 python: python-is-python3
+libunwind8: libunwind-14
+libunwind-dev: libunwind-14-dev


### PR DESCRIPTION
libunwind-8 and libunwind-dev are not available on ubuntu 22.04
and causing perf and pmu-tools installation failed.

Updated to libunwind-14 and libunwind-14-dev to fix the installation
issue.

Signed-off-by: Ng, Shui Lei <shui.lei.ng@intel.com>