### PR TITLE
libperl and perl-module: update version for ubuntu22.04

### DIFF
--- a/distro/adaptation/ubuntu-22.04
+++ b/distro/adaptation/ubuntu-22.04
@@ -1,3 +1,5 @@
 python: python-is-python3
 libunwind8: libunwind-14
 libunwind-dev: libunwind-14-dev
+libperl5: libperl5.34
+perl-modules-5: perl-modules-5.34


### PR DESCRIPTION
libperl5.26 and perl-modules-5.26 are not available on ubuntu 22.04 and
causing unixbench installation failure.

Updated to libperl5.34 and perl-modules-5.34 to fix installation issue.

Signed-off-by: Ng, Shui Lei <shui.lei.ng@intel.com>