### PR TITLE
perf: update dependency package

### DIFF
--- a/distro/adaptation/ubuntu-22.04
+++ b/distro/adaptation/ubuntu-22.04
@@ -3,3 +3,4 @@ libunwind8: libunwind-14
 libunwind-dev: libunwind-14-dev
 libperl5: libperl5.34
 perl-modules-5: perl-modules-5.34
+python-setuptools: python3-setuptools

--- a/distro/depends/perf
+++ b/distro/depends/perf
@@ -4,3 +4,4 @@ libunwind8
 libzstd-dev
 numactl
 libpython2.7
+python-setuptools


### PR DESCRIPTION
python-setuptools may not install by default on the system.
perf: Add dependency package to fix compilation failure.

Signed-off-by: Ng, Shui Lei <shui.lei.ng@intel.com>