### PR TITLE
coremark: add coremark benchmark

### DIFF
--- a/distro/adaptation-pkg/debian
+++ b/distro/adaptation-pkg/debian
@@ -119,3 +119,4 @@ phoronix-test-suite::
 bpftrace::
 kernbench::
 rt-app::
+coremark::

--- a/distro/adaptation-pkg/ubuntu
+++ b/distro/adaptation-pkg/ubuntu
@@ -117,3 +117,4 @@ phoronix-test-suite::
 bpftrace::
 kernbench::
 rt-app::
+coremark::

--- a/jobs/coremark.yaml
+++ b/jobs/coremark.yaml
@@ -1,0 +1,5 @@
+suite: coremark
+testcase: coremark
+category: benchmark
+
+coremark:

--- a/lib/stats.rb
+++ b/lib/stats.rb
@@ -54,7 +54,7 @@ class LinuxTestcasesTableSet
        pmbench linkbench rocksdb cassandra redis power-idle
        mongodb ycsb memtier mcperf fio-jbod cyclictest filebench igt
        autonuma-benchmark adrestia kernbench rt-app migratepages intel-ipsec-mb
-       simd-stress bpftrace stress-ng].freeze
+       simd-stress bpftrace stress-ng coremark].freeze
   LINUX_TESTCASES =
     %w[analyze-suspend boot blktests cpu-hotplug ext4-frags ftq ftrace-onoff fwq
        galileo irda-kernel kernel-builtin kernel-selftests kvm-unit-tests kvm-unit-tests-qemu

--- a/pkg/coremark/PKGBUILD
+++ b/pkg/coremark/PKGBUILD
@@ -1,0 +1,18 @@
+pkgname=coremark
+pkgver=git
+pkgrel=1
+arch=('i386' 'x86_64' 'riscv64')
+url="https://github.com/eembc/coremark.git"
+license=('GPL')
+source=("https://github.com/eembc/coremark.git")
+md5sums=('SKIP')
+
+build()
+{
+	cd "${srcdir}/${pkgname}"
+	make XCFLAGS="$CFLAGS -DMULTITHREAD=`nproc` -DUSE_FORK=1" compile
+}
+package() {
+	mkdir -p "${pkgdir}/lkp/benchmarks/${pkgname}"
+	cp -af "$srcdir/${pkgname}/"* "${pkgdir}/lkp/benchmarks/${pkgname}"
+}

--- a/spec/stats/coremark/01
+++ b/spec/stats/coremark/01
@@ -1,0 +1,32 @@
+Running coremark benchmark...
+2022-08-30 17:45:28 ./coremark.exe
+2K performance run parameters for coremark.
+CoreMark Size    : 666
+Total ticks      : 19715
+Total time (secs): 19.715000
+Iterations/Sec   : 12173.471976
+Iterations       : 240000
+Compiler version : GCC11.2.0
+Compiler flags   : -O2 -O2 -pipe -fstack-protector-strong --param=ssp-buffer-size=4 -DMULTITHREAD=4 -DUSE_FORK=1  -lrt
+Parallel Fork : 4
+Memory location  : Please put data memory location here
+			(e.g. code in flash, data on heap etc)
+seedcrc          : 0xe9f5
+[0]crclist       : 0xe714
+[1]crclist       : 0xe714
+[2]crclist       : 0xe714
+[3]crclist       : 0xe714
+[0]crcmatrix     : 0x1fd7
+[1]crcmatrix     : 0x1fd7
+[2]crcmatrix     : 0x1fd7
+[3]crcmatrix     : 0x1fd7
+[0]crcstate      : 0x8e3a
+[1]crcstate      : 0x8e3a
+[2]crcstate      : 0x8e3a
+[3]crcstate      : 0x8e3a
+[0]crcfinal      : 0xbd59
+[1]crcfinal      : 0xbd59
+[2]crcfinal      : 0xbd59
+[3]crcfinal      : 0xbd59
+Correct operation validated. See README.md for run and reporting rules.
+CoreMark 1.0 : 12173.471976 / GCC11.2.0 -O2 -O2 -pipe -fstack-protector-strong --param=ssp-buffer-size=4 -DMULTITHREAD=4 -DUSE_FORK=1  -lrt / Heap / 4:Fork

--- a/spec/stats/coremark/01.yaml
+++ b/spec/stats/coremark/01.yaml
@@ -1,0 +1,1 @@
+iterations_per_sec:  12173.471976

--- a/stats/coremark
+++ b/stats/coremark
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+LKP_SRC = ENV['LKP_SRC'] || File.dirname(File.dirname(File.realpath($PROGRAM_NAME)))
+
+require "#{LKP_SRC}/lib/log"
+require "#{LKP_SRC}/lib/string_ext"
+
+while (line = $stdin.gets)
+  line = line.resolve_invalid_bytes
+  case line
+  when /^Iterations\/Sec/
+    sub_str = line.split(':', 2)
+    # Iteration per sec
+    iterations_per_sec = sub_str[1]
+    puts "iterations_per_sec: #{iterations_per_sec}"
+  end
+end

--- a/tests/coremark
+++ b/tests/coremark
@@ -1,0 +1,13 @@
+#!/bin/sh
+# - coremark
+
+. $LKP_SRC/lib/upload.sh
+. $LKP_SRC/lib/unit.sh
+. $LKP_SRC/lib/reproduce-log.sh
+
+cd $BENCHMARK_ROOT/coremark || die "no $BENCHMARK_ROOT/coremark"
+
+echo "Running coremark benchmark..."
+
+log_cmd ./coremark.exe
+

--- a/tests/coremark.yaml
+++ b/tests/coremark.yaml
@@ -1,0 +1,15 @@
+short_description: >
+ This is a test of EEMBC CoreMark processor benchmark.
+
+description: |
+ This is a test of EEMBC CoreMark processor benchmark
+ to measures the performance of central processing units by 
+ measuring the number of iteration (algo: CRC, list processing,
+ matric manipulation, state machine ) per second.
+
+homepage: https://www.eembc.org/coremark/
+
+parameters:
+ 
+results:
+ coremark:iterations_per_sec:


### PR DESCRIPTION
This is a test of EEMBC CoreMark processor benchmark that measure the
number of iteration per second of specific algorithms.

Signed-off-by: Ng, Shui Lei <shui.lei.ng@intel.com>