### PR TITLE
hackbench: add riscv64 support

### DIFF
--- a/pkg/hackbench/PKGBUILD
+++ b/pkg/hackbench/PKGBUILD
@@ -1,7 +1,7 @@
 pkgname=hackbench
 pkgver=2.4
 pkgrel=1
-arch=('i386' 'x86_64')
+arch=('i386' 'x86_64' 'riscv64')
 url="https://www.kernel.org/pub/linux/utils/rt-tests"
 license=('GPL')
 # The url for latest pkg is https://www.kernel.org/pub/linux/utils/rt-tests/rt-tests-${pkgver}.tar.gz


### PR DESCRIPTION
hackbench supports riscv64 architecture and able to run on riscv64 board.

Signed-off-by: Ng, Shui Lei <shui.lei.ng@intel.com>