### PR TITLE
fio: enable fio test on ubuntu

### DIFF
--- a/distro/adaptation-pkg/ubuntu
+++ b/distro/adaptation-pkg/ubuntu
@@ -118,3 +118,4 @@ bpftrace::
 kernbench::
 rt-app::
 coremark::
+fio::


### PR DESCRIPTION
fio by default is not enable on ubuntu on lkp-tests, which causing
"fio: command not found" error when running the fio test on ubuntu.

distro/adaptation-pkg/ubuntu: added fio

Signed-off-by: Ng, Shui Lei <shui.lei.ng@intel.com>