### PR TITLE
fio: add new fio job file and enhancements for fio tests

### DIFF
--- a/jobs/fio-basic-1hdd-write-large-memory.yaml
+++ b/jobs/fio-basic-1hdd-write-large-memory.yaml
@@ -8,7 +8,9 @@ need_memory: 6G
 
 disk: 1HDD
 fs:
-  - xfs
+  fs:
+    - xfs
+  format: y
 
 nr_task:
   - 1

--- a/jobs/fio-basic-1hdd-write.yaml
+++ b/jobs/fio-basic-1hdd-write.yaml
@@ -6,9 +6,11 @@ runtime: 300s
 
 disk: 1HDD
 fs:
-  - ext4
-  - btrfs
-  - xfs
+  fs:
+    - ext4
+    - btrfs
+    - xfs
+  format: y
 
 nr_task:
   - 1
@@ -48,7 +50,9 @@ fio-setup-basic:
 fio:
 
 ---
-fs: btrfs
+fs:
+  fs: btrfs
+  format: y
 fio-setup-basic:
   rw: randwrite
   bs:
@@ -69,7 +73,9 @@ fio-setup-basic:
     - filestat
     - filedelete
 ---
-fs: ext4
+fs:
+  fs: ext4
+  format: y
 test_size: 32G
 fio-setup-basic:
   rw: randwrite
@@ -80,7 +86,9 @@ fio-setup-basic:
     - sync
     - io_uring
 ---
-fs: ext4
+fs:
+  fs: ext4
+  format: y
 
 fio-setup-basic:
   rw: write
@@ -118,7 +126,9 @@ fio-setup-basic:
     - 100
     - 200
 ---
-fs: ext4
+fs:
+  fs: ext4
+  format: y
 nr_task: 1
 fio-setup-basic:
   rw: write

--- a/jobs/fio-basic-1ssd-nvme-write-nfs.yaml
+++ b/jobs/fio-basic-1ssd-nvme-write-nfs.yaml
@@ -3,7 +3,9 @@ testcase: fio-basic
 category: benchmark
 
 disk: 1SSD
-fs: ext4
+fs: 
+  fs: ext4
+  format: y
 fs2: nfsv4
 
 runtime: 300s

--- a/jobs/fio-basic-1ssd-nvme-write.yaml
+++ b/jobs/fio-basic-1ssd-nvme-write.yaml
@@ -4,9 +4,11 @@ category: benchmark
 
 disk: 1SSD
 fs:
-  - ext4
-  - xfs
-  - btrfs
+  fs:
+    - ext4
+    - xfs
+    - btrfs
+  format: y
 
 runtime: 300s
 nr_task: 8
@@ -33,7 +35,9 @@ fio-setup-basic:
   test_size: 256g
 
 ---
-fs: xfs
+fs: 
+  fs: xfs
+  format: y
 
 nr_task: 32
 
@@ -46,7 +50,9 @@ fio-setup-basic:
   test_size: 256g
 
 ---
-fs: btrfs
+fs: 
+  fs: btrfs
+  format: y
 
 nr_task: 8
 
@@ -59,7 +65,9 @@ fio-setup-basic:
   test_size: 256g
 
 ---
-fs: ext4
+fs: 
+  fs: ext4
+  format: y
 
 nr_task: 64
 
@@ -72,7 +80,9 @@ fio-setup-basic:
   test_size: 256g
 
 ---
-fs: ext4
+fs: 
+  fs: ext4
+  format: y
 
 nr_task: 4
 
@@ -85,7 +95,9 @@ fio-setup-basic:
   test_size: 256g
 
 ---
-fs: ext4
+fs: 
+  fs: ext4
+  format: y
 
 nr_task: 16
 

--- a/jobs/fio-basic-1ssd-write.yaml
+++ b/jobs/fio-basic-1ssd-write.yaml
@@ -6,9 +6,11 @@ runtime: 300s
 
 disk: 1SSD
 fs:
-  - ext4
-  - btrfs
-  - xfs
+  fs:
+    - ext4
+    - btrfs
+    - xfs
+  format: y
 
 nr_task:
   - 1
@@ -36,7 +38,9 @@ fio-setup-basic:
 fio:
 
 ---
-fs: btrfs
+fs:
+  fs: btrfs
+  format: y
 fio-setup-basic:
   rw: randwrite
   bs:
@@ -58,7 +62,9 @@ fio-setup-basic:
 
 ---
 runtime: 20m
-fs: ext4
+fs:
+  fs: ext4
+  format: y
 test_size: 32G
 fio-setup-basic:
   rw: randwrite
@@ -70,7 +76,9 @@ fio-setup-basic:
     - io_uring
 
 ---
-fs: ext4
+fs:
+  fs: ext4
+  format: y
 
 fio-setup-basic:
   rw: write
@@ -108,7 +116,9 @@ fio-setup-basic:
     - 100
     - 200
 ---
-fs: ext4
+fs:
+  fs: ext4
+  format: y
 nr_task: 1
 fio-setup-basic:
   rw: write

--- a/jobs/fio-basic-2pmem-256G.yaml
+++ b/jobs/fio-basic-2pmem-256G.yaml
@@ -10,8 +10,10 @@ boot_params:
 disk: 2pmem
 
 fs:
-  - ext4
-  - xfs
+  fs:
+    - ext4
+    - xfs
+  format: y
 
 runtime: 200s
 
@@ -40,7 +42,9 @@ fio-setup-basic:
 fio:
 
 ---
-fs: ext2
+fs:
+  fs: ext2
+  format: y
 
 fio-setup-basic:
   rw:
@@ -58,7 +62,9 @@ fio-setup-basic:
   test_size: 200G
 
 ---
-fs: btrfs
+fs:
+  fs: btrfs
+  format: y
 
 fio-setup-basic:
   rw:

--- a/jobs/fio-basic-2pmem-dax-256G.yaml
+++ b/jobs/fio-basic-2pmem-dax-256G.yaml
@@ -13,6 +13,7 @@ fs:
   fs:
     - ext4
     - xfs
+  format: y
   mount_option: dax
 
 runtime: 200s
@@ -44,6 +45,7 @@ fio:
 ---
 fs:
   fs: ext2
+  format: y
   mount_option: dax
 
 fio-setup-basic:

--- a/jobs/fio-basic-2pmem-dax-lkp-csl-2sp2.yaml
+++ b/jobs/fio-basic-2pmem-dax-lkp-csl-2sp2.yaml
@@ -11,6 +11,7 @@ fs:
   fs:
     - ext4
     - xfs
+  format: y
   mount_option: dax
 
 runtime: 200s

--- a/jobs/fio-basic-2pmem.yaml
+++ b/jobs/fio-basic-2pmem.yaml
@@ -13,6 +13,7 @@ need_memory: 256G
 disk: 2pmem
 fs:
   fs: ext4
+  format: y
   mount_option: dax
 
 runtime: 300s

--- a/jobs/fio-basic-local-disk.yaml
+++ b/jobs/fio-basic-local-disk.yaml
@@ -4,28 +4,33 @@ testcase: fio-basic
 category: benchmark
 
 runtime: 300s
-nr_task: 8t
+nr_task:
+  - 1
+  - 4
 
 disk: 1SSD
 fs:
-  fs:
-    - ext4
-    - xfs
-    - btrfs
-    - f2fs
-  format: y
+  fs: ext4
+  format: n
 
 fio-setup-basic:
   rw:
     - read
+    - write
     - randread
+    - randwrite
+    - readwrite
+    - randrw
+  direct: 1
   bs:
     - 4k
-    - 2M
+    - 1M
   ioengine:
-    - sync
     - libaio
     - io_uring
-  test_size: 256g
+  iodepth:
+    - 1
+    - 32
+  test_size: 1g
 
 fio:

--- a/jobs/fio-basic-pagecache-demo.yaml
+++ b/jobs/fio-basic-pagecache-demo.yaml
@@ -12,7 +12,9 @@ numactl:
 
 disk: 1SSD
 fs:
-  - ext4
+  fs:
+    - ext4
+  format: y
 
 drop_caches:
 sysctl:

--- a/jobs/fio-jbod-12hdd-randwrite-sync-4k.yaml
+++ b/jobs/fio-jbod-12hdd-randwrite-sync-4k.yaml
@@ -5,7 +5,9 @@ category: benchmark
 disk:
   - 12HDD
 fs:
-  - ext4
+  fs:
+    - ext4
+  format: y
 
 fio:
   rw:

--- a/jobs/fio-jbod-12hdd.yaml
+++ b/jobs/fio-jbod-12hdd.yaml
@@ -5,7 +5,9 @@ category: benchmark
 disk:
   - 12HDD
 fs:
-  - ext4
+  fs:
+    - ext4
+  format: y
 
 fio:
   rw:

--- a/setup/fio-setup-basic
+++ b/setup/fio-setup-basic
@@ -179,11 +179,26 @@ parse_numa_mem_policy
 parse_numa_cpu_nodes
 
 no=0
+
 for storage in $storages; do
 	if [ "$raw_disk" = 1 ]; then
 		storage_setup="filename=$storage"
 	else
-		storage_setup="directory=$storage"
+		dev=/dev/$(basename $storage)
+		if [[ "$storage" =~ "/null" ]]; then
+			storage_setup="filename=/dev/nullb0"
+		elif [[ $(df | grep $dev | awk '{print $6}') == '/' ]]; then
+			[ -d "/lkp/benchmarks/fio" ] || mkdir /lkp/benchmarks/fio
+			storage_setup="\
+directory=/lkp/benchmarks/fio
+filename=fio_testfile_local
+"
+		else
+			storage_setup="\
+directory=$storage
+filename=fio_testfile
+"
+		fi
 	fi
         if [ "$ioengine" = "sg" ]; then
                 dev_src=$(findmnt $storage -no source)

--- a/setup/fs
+++ b/setup/fs
@@ -1,5 +1,6 @@
 #!/bin/sh
 # - fs
+# - format
 # - mkfs
 # - mount
 # - mount_option
@@ -96,7 +97,9 @@ make_fs() {
 	local pids=
 	for dev in $bdevs
 	do
-		log_cmd mkfs -t $fs ${mkfs:-$def_mkfs} $ensure_mkfs $dev &
+		if [ "$format" = 'y' ]; then
+			log_cmd mkfs -t $fs ${mkfs:-$def_mkfs} $ensure_mkfs $dev &
+		fi
 		pids="${pids} $! "
 	done
 
@@ -116,9 +119,11 @@ mount_fs() {
 	for dev in $bdevs
 	do
 		local mnt=/fs/$(basename $dev)
-		log_cmd mkdir -p $mnt
+		[[ $(df | grep $dev | awk '{print $6}') == '/' ]] || log_cmd mkdir -p $mnt
 		probe_filesystem $fs
-		log_cmd mount -t $fs ${mount:-$def_mount} $mount_option $dev $mnt || exit
+		if [[ ! "$dev" =~ "/null" ]] && [[ $(df | grep $dev | awk '{print $6}') != '/' ]]; then
+			log_cmd mount -t $fs ${mount:-$def_mount} $mount_option $dev $mnt || exit
+		fi
 		mount_points="${mount_points}$mnt "
 	done
 }
@@ -151,10 +156,12 @@ case $fs in
 
 	*)
 		. $LKP_SRC/lib/fs_ext.sh
-		if [ -n "$raid_device" ] || [ -n "$LKP_LOCAL_RUN" ]; then
-			destroy_fs
-		else
-			destroy_devices
+		if [ "$format" = 'y' ]; then
+			if [ -n "$raid_device" ] || [ -n "$LKP_LOCAL_RUN" ]; then
+				destroy_fs
+			else
+				destroy_devices
+			fi
 		fi
 		make_fs
 		mount_fs

--- a/setup/fs
+++ b/setup/fs
@@ -97,7 +97,7 @@ make_fs() {
 	local pids=
 	for dev in $bdevs
 	do
-		if [ "$format" = 'y' ]; then
+		if [ ! "$format" = 'n' ]; then
 			log_cmd mkfs -t $fs ${mkfs:-$def_mkfs} $ensure_mkfs $dev &
 		fi
 		pids="${pids} $! "
@@ -156,7 +156,7 @@ case $fs in
 
 	*)
 		. $LKP_SRC/lib/fs_ext.sh
-		if [ "$format" = 'y' ]; then
+		if [ ! "$format" = 'n' ]; then
 			if [ -n "$raid_device" ] || [ -n "$LKP_LOCAL_RUN" ]; then
 				destroy_fs
 			else


### PR DESCRIPTION
- Add format option to determine whether to wipe and format target
  partition or not
- If target is local partition mounted on '/' fio tests will write
  fio testfile in /lkp/benchmarks/fio
- If target is null block device, filename target will be the null
  block
- Add new job file fio-basic-local-disk

Signed-off-by: Lim, Lukaz Wei Hwang <lukaz.wei.hwang.lim@intel.com>