### PR TITLE
fio: add new job file for testing on local storage and enhancements for fio tests

### DIFF
--- a/jobs/fio-basic-local-disk.yaml
+++ b/jobs/fio-basic-local-disk.yaml
@@ -32,5 +32,6 @@ fio-setup-basic:
     - 1
     - 32
   test_size: 1g
+  testfile: y
 
 fio:

--- a/jobs/fio-basic-local-disk.yaml
+++ b/jobs/fio-basic-local-disk.yaml
@@ -1,0 +1,36 @@
+suite: fio-basic
+testcase: fio-basic
+
+category: benchmark
+
+runtime: 300s
+nr_task:
+  - 1
+  - 4
+
+disk: 1SSD
+fs:
+  fs: ext4
+  format: n
+
+fio-setup-basic:
+  rw:
+    - read
+    - write
+    - randread
+    - randwrite
+    - readwrite
+    - randrw
+  direct: 1
+  bs:
+    - 4k
+    - 1M
+  ioengine:
+    - libaio
+    - io_uring
+  iodepth:
+    - 1
+    - 32
+  test_size: 1g
+
+fio:

--- a/lib/fs_ext.sh
+++ b/lib/fs_ext.sh
@@ -172,3 +172,9 @@ mount_tmpfs()
 		mount_points="${mount_points}$mnt "
 	done
 }
+
+is_null_blk()
+{
+	local dev=$1
+	[ $(echo "$dev" | grep -Fe "/null") ]
+}

--- a/lib/fs_ext.sh
+++ b/lib/fs_ext.sh
@@ -178,3 +178,9 @@ is_null_blk()
 	local dev=$1
 	[ $(echo "$dev" | grep -Fe "/null") ]
 }
+
+is_mount_on_root()
+{
+	local dev=$1
+	[ "$(df | grep $dev | grep -o '\S\+$')" = "/" ]
+}

--- a/setup/fio-setup-basic
+++ b/setup/fio-setup-basic
@@ -187,6 +187,16 @@ for storage in $storages; do
 		storage_setup="filename=$storage"
 	elif is_null_blk /dev/$(basename $storage); then
 		storage_setup="filename=/dev/nullb0"
+	elif is_mount_on_root /dev/$(basename $storage); then
+		[ -d "/lkp/benchmarks/fio" ] || mkdir /lkp/benchmarks/fio
+		if [ "$testfile" = 'y' ]; then
+			storage_setup="\
+directory=/lkp/benchmarks/fio
+filename=fio_testfile_local
+"
+		else
+			storage_setup="directory=/lkp/benchmarks/fio"
+		fi
 	elif [ "$testfile" = 'y' ]; then
 		storage_setup="\
 directory=$storage

--- a/setup/fio-setup-basic
+++ b/setup/fio-setup-basic
@@ -28,6 +28,7 @@
 . $LKP_SRC/lib/common.sh
 . $LKP_SRC/lib/unit.sh
 . $LKP_SRC/lib/debug.sh
+. $LKP_SRC/lib/fs_ext.sh
 
 [ -n "$test_size" ] || die "test_size must be specified for fio"
 
@@ -184,6 +185,8 @@ no=0
 for storage in $storages; do
 	if [ "$raw_disk" = 1 ]; then
 		storage_setup="filename=$storage"
+	elif is_null_blk /dev/$(basename $storage); then
+		storage_setup="filename=/dev/nullb0"
 	elif [ "$testfile" = 'y' ]; then
 		storage_setup="\
 directory=$storage

--- a/setup/fio-setup-basic
+++ b/setup/fio-setup-basic
@@ -22,6 +22,7 @@
 # - rwmixread
 # - cpuload
 # - donorname
+# - testfile
 
 . $LKP_SRC/lib/reproduce-log.sh
 . $LKP_SRC/lib/common.sh
@@ -179,9 +180,15 @@ parse_numa_mem_policy
 parse_numa_cpu_nodes
 
 no=0
+
 for storage in $storages; do
 	if [ "$raw_disk" = 1 ]; then
 		storage_setup="filename=$storage"
+	elif [ "$testfile" = 'y' ]; then
+		storage_setup="\
+directory=$storage
+filename=fio_testfile
+"
 	else
 		storage_setup="directory=$storage"
 	fi

--- a/setup/fs
+++ b/setup/fs
@@ -1,5 +1,6 @@
 #!/bin/sh
 # - fs
+# - format
 # - mkfs
 # - mount
 # - mount_option
@@ -96,7 +97,9 @@ make_fs() {
 	local pids=
 	for dev in $bdevs
 	do
-		log_cmd mkfs -t $fs ${mkfs:-$def_mkfs} $ensure_mkfs $dev &
+		if [ ! "$format" = 'n' ]; then
+			log_cmd mkfs -t $fs ${mkfs:-$def_mkfs} $ensure_mkfs $dev &
+		fi
 		pids="${pids} $! "
 	done
 
@@ -151,10 +154,12 @@ case $fs in
 
 	*)
 		. $LKP_SRC/lib/fs_ext.sh
-		if [ -n "$raid_device" ] || [ -n "$LKP_LOCAL_RUN" ]; then
-			destroy_fs
-		else
-			destroy_devices
+		if [ ! "$format" = 'n' ]; then
+			if [ -n "$raid_device" ] || [ -n "$LKP_LOCAL_RUN" ]; then
+				destroy_fs
+			else
+				destroy_devices
+			fi
 		fi
 		make_fs
 		mount_fs

--- a/setup/fs
+++ b/setup/fs
@@ -119,9 +119,9 @@ mount_fs() {
 	for dev in $bdevs
 	do
 		local mnt=/fs/$(basename $dev)
-		log_cmd mkdir -p $mnt
+		is_mount_on_root $dev || log_cmd mkdir -p $mnt
 		probe_filesystem $fs
-		if ! is_null_blk $dev; then
+		if ! is_null_blk $dev && ! is_mount_on_root $dev; then
 			log_cmd mount -t $fs ${mount:-$def_mount} $mount_option $dev $mnt || exit
 		fi
 		mount_points="${mount_points}$mnt "

--- a/setup/fs
+++ b/setup/fs
@@ -121,7 +121,9 @@ mount_fs() {
 		local mnt=/fs/$(basename $dev)
 		log_cmd mkdir -p $mnt
 		probe_filesystem $fs
-		log_cmd mount -t $fs ${mount:-$def_mount} $mount_option $dev $mnt || exit
+		if ! is_null_blk $dev; then
+			log_cmd mount -t $fs ${mount:-$def_mount} $mount_option $dev $mnt || exit
+		fi
 		mount_points="${mount_points}$mnt "
 	done
 }


### PR DESCRIPTION
- Add 'format: n' parameter for fs will skip formatting of target partition
- Add support for fio tests to run on null block device
- Set fio testfile directory to /lkp/benchmarks/fio if target partition is local storage (root partition '/')

To support fio tests on local storage and null block device with new fio job file fio-basic-local-disk.yaml