### PR TITLE
stress-ng: fix install failed issue on ubuntu 22.04

### DIFF
--- a/distro/adaptation/ubuntu
+++ b/distro/adaptation/ubuntu
@@ -10,7 +10,7 @@ iblz4-1:liblz4-dev
 libbz2-1.0:libbz2-dev
 libcpupower-dev:
 libevent-2: libevent-dev
-libgcrypt-dev: libgcrypt11-dev
+libgcrypt-dev: libgcrypt20-dev
 libgflags2v5:libgflags-dev
 libhugetlbfs-bin: hugepages
 libhugetlbfs: libhugetlbfs0

--- a/distro/adaptation/ubuntu-22.04
+++ b/distro/adaptation/ubuntu-22.04
@@ -6,3 +6,4 @@ perl-modules-5: perl-modules-5.34
 libx32gcc1: libx32gcc-s1
 lib32gcc-dev: lib32gcc-12-dev
 libx32gcc-dev: libx32gcc-12-dev
+libipsec-mb0: libipsec-mb1


### PR DESCRIPTION
update mapping for libgcrypt-dev and libipsec-mb
libgcrypt20-dev is available since ubuntu 18.04, libipsec-mb0 change to libipsec-mb1 since ubuntu 21.10

== fix issue ==

Use: /home/lkp-tests/distro/installer/ubuntu install libaio1 libapparmor1 libattr1 libbsd0 libcap2 libgcrypt20 libipsec-mb0 libjudydebian1 libkeyutils1 libsctp1 libaio-dev libapparmor-dev libattr1-dev libbsd-dev libcap-dev libgcrypt11-dev libipsec-mb-dev libjudy-dev libkeyutils-dev libsctp-dev linux-libc-dev zlib1g-dev Hit:1 http://archive.ubuntu.com/ubuntu jammy InRelease Get:2 http://security.ubuntu.com/ubuntu jammy-security InRelease [110 kB] Get:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease [114 kB] Get:4 http://archive.ubuntu.com/ubuntu jammy-backports InRelease [99.8 kB] Fetched 324 kB in 1s (251 kB/s)
Reading package lists... Done
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
E: Unable to locate package libipsec-mb0
E: Unable to locate package libgcrypt11-dev
Cannot install some packages in /home/lkp-tests/distro/depends/stress-ng

Signed-off-by: Kenny Gong <kenny.gong@intel.com>