### PR TITLE
Tweak autonuma test

### DIFF
--- a/jobs/autonuma-benchmark.yaml
+++ b/jobs/autonuma-benchmark.yaml
@@ -6,6 +6,7 @@ autonuma-benchmark:
   test:
     - numa02_SMT
     - numa01_THREAD_ALLOC
+    - numa02SMT_numa01THREAD_ALLOC
     - _HARD_BIND
     - _INVERSE_BIND
     - minimal_thread_per_numa

--- a/tests/autonuma-benchmark
+++ b/tests/autonuma-benchmark
@@ -22,6 +22,9 @@ case "$test" in
     "numa01_THREAD_ALLOC")
         option="-t"
         ;;
+    "numa02SMT_numa01THREAD_ALLOC")
+        option="-s -t"
+        ;;
     "_HARD_BIND")
         option="-b"
         ;;
@@ -40,5 +43,5 @@ cd "/lkp/benchmarks/autonuma-benchmark" || die "no /lkp/benchmarks/autonuma-benc
 
 for i in $(seq $iterations)
 do
-  /bin/bash start_bench.sh $option 2>&1
+  /bin/bash start_bench.sh $option 2>&1 || die "Autonuma run failed, check result log"
 done


### PR DESCRIPTION
Couple of tweaks:
1. add variant to run both numa02_SMT and numa01_THREAD_ALLOC in single run.
2. die test if first iteration fails.

Signed-off-by: Srikanth Aithal <srikanth.aithal@amd.com>