### PR TITLE
Update dependencies for perf on redhat

### DIFF
--- a/distro/adaptation/redhat-8
+++ b/distro/adaptation/redhat-8
@@ -1,0 +1,1 @@
+python-setuptools: python2-setuptools

--- a/distro/adaptation/redhat-9
+++ b/distro/adaptation/redhat-9
@@ -1,0 +1,5 @@
+libpython2.7: python3-libs
+python-dev: python3-devel 
+python: python3
+python-minimal: python3
+python-setuptools: python3-setuptools


### PR DESCRIPTION
Currently perf dependencies fail to install
on rhel8.x and rhel9.x. This commit updates
dependencies.

Signed-off-by: Srikanth Aithal <srikanth.aithal@amd.com>