### PR TITLE
Added changes to schbench stats in LKP

### DIFF
--- a/spec/stats/schbench/01.yaml
+++ b/spec/stats/schbench/01.yaml
@@ -16,3 +16,17 @@ latency_min_us: 23.89
 latency_min_us_stddev: 17.48
 latency_max_us: 63263.56
 latency_max_us_stddev: 2.39
+end_latency_50%_us_max: 11536
+end_latency_50%_us_stddev: 1.74
+end_latency_75%_us_max: 26976
+end_latency_75%_us_stddev: 3.38
+end_latency_90%_us_max: 33856
+end_latency_90%_us_stddev: 1.27
+end_latency_95%_us_max: 43200
+end_latency_95%_us_stddev: 0.85
+end_latency_99%_us_max: 50496
+end_latency_99%_us_stddev: 0.32
+end_latency_99.5%_us_max: 52800
+end_latency_99.5%_us_stddev: 0.8
+end_latency_99.9%_us_max: 62784
+end_latency_99.9%_us_stddev: 3.27

--- a/stats/schbench
+++ b/stats/schbench
@@ -5,23 +5,34 @@ LKP_SRC = ENV['LKP_SRC'] || File.dirname(File.dirname(File.realpath($PROGRAM_NAM
 require "#{LKP_SRC}/lib/statistics"
 
 stats = Hash.new { |h, k| h[k] = [] }
+end_latency = Hash.new { |h, k| h[k] = [] }
+counter = -1
 
 $stdin.each_line do |line|
   case line
+  when /^Iteration/
+    counter += 1
   when /50.0th/
     stats['latency_50%_us'] << line.split[1].to_i
+    end_latency['latency_50%_us'][counter] = line.split[1].to_i
   when /75.0th/
     stats['latency_75%_us'] << line.split[1].to_i
+    end_latency['latency_75%_us'][counter] = line.split[1].to_i
   when /90.0th/
     stats['latency_90%_us'] << line.split[1].to_i
+    end_latency['latency_90%_us'][counter] = line.split[1].to_i
   when /95.0th/
     stats['latency_95%_us'] << line.split[1].to_i
+    end_latency['latency_95%_us'][counter] = line.split[1].to_i
   when /99.0th/
     stats['latency_99%_us'] << line.split[1].to_i
+    end_latency['latency_99%_us'][counter] = line.split[1].to_i
   when /99.5th/
     stats['latency_99.5%_us'] << line.split[1].to_i
+    end_latency['latency_99.5%_us'][counter] = line.split[1].to_i
   when /99.9th/
     stats['latency_99.9%_us'] << line.split[1].to_i
+    end_latency['latency_99.9%_us'][counter] = line.split[1].to_i
   when /min/
     line = line.gsub(/([,=])/, ' ')
     stats["latency_#{line.split[0]}_us"] << line.split[1].to_i
@@ -32,4 +43,9 @@ end
 stats.each do |k, v|
   puts "#{k}: #{v.average.round(2)}"
   puts "#{k}_stddev: #{v.relative_stddev.round(2)}"
+end
+
+end_latency.each do |k, v|
+  puts "end_#{k}_max: #{v.max}"
+  puts "end_#{k}_stddev: #{v.relative_stddev.round(2)}"
 end


### PR DESCRIPTION
Added changes to schbench stats to get the max and relative standard deviation of the end latency's between the iterations. Updated the spec/stats for the same.

Signed-off-by: Swapnil Sapkal <swapnil.sapkal@amd.com>