### PR TITLE
repo/linux/conor: enable public reporting for riscv branches

### DIFF
--- a/repo/linux/conor
+++ b/repo/linux/conor
@@ -2,5 +2,8 @@ url: https://git.kernel.org/pub/scm/linux/kernel/git/conor/linux.git
 owner: Conor Dooley <conor@kernel.org>
 notify_build_success_branch: .*
 private_report_branch: .*
+public_report_branch: riscv-.*
+subsystems:
+- riscv
 mail_to: Conor Dooley <conor+lkp@kernel.org>
 


### PR DESCRIPTION
Since I am now taking patches for non-microchip contributions through my tree, it seems silly to keep the LKP reports private!

I looked, but admittedly not super hard, for documentation on the behaviour of the properties here.
I'd kinda like if I didn't spam people with the BUILD_SUCCESS emails for the branches with public reporting, but I am not sure how exactly to achieve that. For that reason, I've made this a draft.