### PR TITLE
repo: add owner mail and notif for matttbe

### DIFF
--- a/repo/linux/matttbe-net-next
+++ b/repo/linux/matttbe-net-next
@@ -1,1 +1,4 @@
 url: https://git.kernel.org/pub/scm/linux/kernel/git/matttbe/net-next.git
+owner: Matthieu Baerts <matthieu.baerts@tessares.net>
+notify_build_success_branch: .*
+mail_cc: matthieu.baerts@tessares.net


### PR DESCRIPTION
To receive notifications when updates are sent to this repository.

This repo is going to be used to validate patches from [MPTCP subsystem](https://github.com/intel/lkp-tests/blob/master/repo/linux/mptcp) to Netdev.

Thank you for running and maintaining this service!