### PR TITLE
pkg/rt-tests: update to version 2.5

### DIFF
--- a/pkg/hackbench/PKGBUILD
+++ b/pkg/hackbench/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=hackbench
-pkgver=2.4
+pkgver=2.5
 pkgrel=1
 arch=('i386' 'x86_64' 'riscv64' 'aarch64')
 url="https://www.kernel.org/pub/linux/utils/rt-tests"

--- a/pkg/rt-tests/PKGBUILD
+++ b/pkg/rt-tests/PKGBUILD
@@ -1,12 +1,12 @@
 pkgname=rt-tests
-pkgver=2.4
+pkgver=2.5
 pkgrel=0
 pkgdesc="Suite of real-time tests - cyclictest, hwlatdetect, pip_stress, pi_stress, pmqtest, ptsematest, rt-migrate-test, sendme, signaltest, sigwaittest, svsematest"
 arch=('i386' 'x86_64' 'aarch64')
 url="https://git.kernel.org/cgit/utils/rt-tests/rt-tests.git/"
 license=('GPL')
 source=("https://www.kernel.org/pub/linux/utils/rt-tests/rt-tests-$pkgver.tar.gz")
-md5sums=('5b88a361399d27520be9e39d536720c9')
+md5sums=('8728ed02282ba065ac3ca2f36a908256')
 
 build() {
         cd "$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
Update the version of rt-tests from 2.4 to 2.5.
Installing hackbench fails with:

```
$ sudo lkp install hackbench-pipe-8-process-50%.yaml
[...]
curl: (22) The requested URL returned error: 404
==> ERROR: Failure while downloading rt-tests-2.4.tar.gz
    Aborting...
[...]
$ wget https://www.kernel.org/pub/linux/utils/rt-tests/rt-tests-2.4.tar.gz
[...]
HTTP request sent, awaiting response... 404 Not Found
```

Signed-off-by: Sebastian Pop <spop@amazon.com>