### PR TITLE
stats/kernel-selftests: add udpgro_fwd.sh process

### DIFF
--- a/spec/stats/kernel-selftests/net-13
+++ b/spec/stats/kernel-selftests/net-13
@@ -1,0 +1,60 @@
+# selftests: net: udpgro_fwd.sh
+# IPv4
+# No GRO                                  exec of "iptables-save" failed: No such file or directory
+# ./udpgro_fwd.sh: line 135: [: !=: unary operator expected
+# exec of "iptables-save" failed: No such file or directory
+# ./udpgro_fwd.sh: line 145: [: too many arguments
+#  ok
+# GRO frag list                           exec of "iptables-save" failed: No such file or directory
+# ./udpgro_fwd.sh: line 135: [: !=: unary operator expected
+# exec of "iptables-save" failed: No such file or directory
+# ./udpgro_fwd.sh: line 145: [: too many arguments
+#  ok
+# GRO fwd                                 exec of "iptables-save" failed: No such file or directory
+# ./udpgro_fwd.sh: line 135: [: !=: unary operator expected
+# exec of "iptables-save" failed: No such file or directory
+# ./udpgro_fwd.sh: line 145: [: too many arguments
+#  ok
+# UDP fwd perf                            udp rx:      4 MB/s     3536 calls/s
+# udp tx:     76 MB/s     1304 calls/s   1304 msg/s
+# udp rx:      5 MB/s     4368 calls/s
+# UDP GRO fwd perf                        udp rx:      4 MB/s     3536 calls/s
+# udp tx:     75 MB/s     1283 calls/s   1283 msg/s
+# udp rx:      5 MB/s     4368 calls/s
+# GRO frag list over UDP tunnel           exec of "iptables-save" failed: No such file or directory
+# ./udpgro_fwd.sh: line 135: [: !=: unary operator expected
+# exec of "iptables-save" failed: No such file or directory
+# ./udpgro_fwd.sh: line 145: [: too many arguments
+#  ok
+# GRO fwd over UDP tunnel                 exec of "iptables-save" failed: No such file or directory
+# ./udpgro_fwd.sh: line 135: [: !=: unary operator expected
+# exec of "iptables-save" failed: No such file or directory
+# ./udpgro_fwd.sh: line 145: [: too many arguments
+#  ok
+# IPv6
+# No GRO                                  exec of "ip6tables-save" failed: No such file or directory
+# ./udpgro_fwd.sh: line 135: [: !=: unary operator expected
+# exec of "ip6tables-save" failed: No such file or directory
+# ./udpgro_fwd.sh: line 145: [: too many arguments
+#  ok
+# GRO frag list                           exec of "ip6tables-save" failed: No such file or directory
+# ./udpgro_fwd.sh: line 135: [: !=: unary operator expected
+# exec of "ip6tables-save" failed: No such file or directory
+# ./udpgro_fwd.sh: line 145: [: too many arguments
+#  ok
+# GRO fwd                                 exec of "ip6tables-save" failed: No such file or directory
+# ./udpgro_fwd.sh: line 135: [: !=: unary operator expected
+# exec of "ip6tables-save" failed: No such file or directory
+# ./udpgro_fwd.sh: line 145: [: too many arguments
+#  ok
+# GRO frag list over UDP tunnel           exec of "ip6tables-save" failed: No such file or directory
+# ./udpgro_fwd.sh: line 135: [: !=: unary operator expected
+# exec of "ip6tables-save" failed: No such file or directory
+# ./udpgro_fwd.sh: line 145: [: too many arguments
+#  ok
+# GRO fwd over UDP tunnel                 exec of "ip6tables-save" failed: No such file or directory
+# ./udpgro_fwd.sh: line 135: [: !=: unary operator expected
+# exec of "ip6tables-save" failed: No such file or directory
+# ./udpgro_fwd.sh: line 145: [: too many arguments
+#  ok
+ok 54 selftests: net: udpgro_fwd.sh

--- a/spec/stats/kernel-selftests/net-13.yaml
+++ b/spec/stats/kernel-selftests/net-13.yaml
@@ -1,0 +1,11 @@
+net.udpgro_fwd.sh.IPv4.No_GRO.pass: 1
+net.udpgro_fwd.sh.IPv4.GRO_frag_list.pass: 1
+net.udpgro_fwd.sh.IPv4.GRO_fwd.pass: 1
+net.udpgro_fwd.sh.IPv4.GRO_frag_list_over_UDP_tunnel.pass: 1
+net.udpgro_fwd.sh.IPv4.GRO_fwd_over_UDP_tunnel.pass: 1
+net.udpgro_fwd.sh.IPv6.No_GRO.pass: 1
+net.udpgro_fwd.sh.IPv6.GRO_frag_list.pass: 1
+net.udpgro_fwd.sh.IPv6.GRO_fwd.pass: 1
+net.udpgro_fwd.sh.IPv6.GRO_frag_list_over_UDP_tunnel.pass: 1
+net.udpgro_fwd.sh.IPv6.GRO_fwd_over_UDP_tunnel.pass: 1
+net.udpgro_fwd.sh.pass: 1

--- a/spec/stats/kernel-selftests/net-14
+++ b/spec/stats/kernel-selftests/net-14
@@ -1,0 +1,22 @@
+# selftests: net: udpgro_fwd.sh
+# IPv4
+# No GRO                                   ok
+# GRO frag list                            ok
+# GRO fwd                                  ok
+# UDP fwd perf                            udp rx:    471 MB/s   382269 calls/s
+# UDP GRO fwd perf                        udp rx:    521 MB/s   420864 calls/s
+# GRO frag list over UDP tunnel            ok
+# GRO fwd over UDP tunnel                  ok
+# UDP tunnel fwd perf                     udp rx:    203 MB/s   165464 calls/s
+# UDP tunnel GRO fwd perf                 udp rx:    211 MB/s   170893 calls/s
+# IPv6
+# No GRO                                   ok
+# GRO frag list                            ok
+# GRO fwd                                  ok
+# UDP fwd perf                            udp rx:    486 MB/s   394352 calls/s
+# UDP GRO fwd perf                        udp rx:    541 MB/s   436646 calls/s
+# GRO frag list over UDP tunnel            ok
+# GRO fwd over UDP tunnel                  ok
+# UDP tunnel fwd perf                     udp rx:    266 MB/s   215668 calls/s
+# UDP tunnel GRO fwd perf                 udp rx:    324 MB/s   261888 calls/s
+ok 2 selftests: net: udpgro_fwd.sh

--- a/spec/stats/kernel-selftests/net-14.yaml
+++ b/spec/stats/kernel-selftests/net-14.yaml
@@ -1,0 +1,11 @@
+net.udpgro_fwd.sh.IPv4.No_GRO.pass: 1
+net.udpgro_fwd.sh.IPv4.GRO_frag_list.pass: 1
+net.udpgro_fwd.sh.IPv4.GRO_fwd.pass: 1
+net.udpgro_fwd.sh.IPv4.GRO_frag_list_over_UDP_tunnel.pass: 1
+net.udpgro_fwd.sh.IPv4.GRO_fwd_over_UDP_tunnel.pass: 1
+net.udpgro_fwd.sh.IPv6.No_GRO.pass: 1
+net.udpgro_fwd.sh.IPv6.GRO_frag_list.pass: 1
+net.udpgro_fwd.sh.IPv6.GRO_fwd.pass: 1
+net.udpgro_fwd.sh.IPv6.GRO_frag_list_over_UDP_tunnel.pass: 1
+net.udpgro_fwd.sh.IPv6.GRO_fwd_over_UDP_tunnel.pass: 1
+net.udpgro_fwd.sh.pass: 1

--- a/stats/kernel-selftests
+++ b/stats/kernel-selftests
@@ -104,6 +104,36 @@ end
 
 class NetStater < Stater
   def stat(line, stats)
+    if @test_script == 'udpgro_fwd.sh'
+      if @test_case && !@test_subcase && line !~ /perf/ && line =~ /^# (.*GRO.*)/
+        # No GRO                                  exec of "iptables-save" failed: No such file or directory
+        @test_subcase = $1.split("\s\s\s").first
+        @test_result = $1.split("\s\s\s").last
+        if @test_result =~ /(ok$|fail |skip )/
+          # No GRO                                   ok
+          stats.add "#{@test_prefix}.#{@test_case}.#{@test_subcase}", $1
+          @test_subcase = nil
+        end
+        return
+      end
+
+      case line
+      when /^# (IPv4|IPv6)$/
+        # IPv4
+        @test_case = $1
+        @test_subcase = nil
+      when /^#\s+(ok$|fail |skip )/
+        if @test_case && @test_subcase
+          stats.add "#{@test_prefix}.#{@test_case}.#{@test_subcase}", $1
+          @test_subcase = nil
+        end
+      else
+        super(line, stats)
+      end
+
+      return
+    end
+
     case line
     # begain for net.fcnal-test.sh
     when /(IPv4 ping|IPv4\/TCP|IPv4\/UDP|IPv4 Netfilter)/,


### PR DESCRIPTION
For following output:
 selftests: net: udpgro_fwd.sh
 IPv4
 No GRO                                  exec of "iptables-save" failed: No such file or directory
 ./udpgro_fwd.sh: line 135: [: !=: unary operator expected
 exec of "iptables-save" failed: No such file or directory
 ./udpgro_fwd.sh: line 145: [: too many arguments
  ok
 GRO frag list                           exec of "iptables-save" failed: No such file or directory
 ./udpgro_fwd.sh: line 135: [: !=: unary operator expected
 exec of "iptables-save" failed: No such file or directory
 ./udpgro_fwd.sh: line 145: [: too many arguments
  ok
 GRO fwd                                 exec of "iptables-save" failed: No such file or directory
 ./udpgro_fwd.sh: line 135: [: !=: unary operator expected
 exec of "iptables-save" failed: No such file or directory
 ./udpgro_fwd.sh: line 145: [: too many arguments
  ok
 UDP fwd perf                            udp rx:      4 MB/s     3536 calls/s
 udp tx:     76 MB/s     1304 calls/s   1304 msg/s
 udp rx:      5 MB/s     4368 calls/s
 udp tx:     76 MB/s     1305 calls/s   1305 msg/s
 udp rx:      5 MB/s     4368 calls/s
 UDP GRO fwd perf                        udp rx:      4 MB/s     3536 calls/s
 udp tx:     75 MB/s     1283 calls/s   1283 msg/s
 udp rx:      5 MB/s     4368 calls/s
 udp tx:     75 MB/s     1277 calls/s   1277 msg/s
 udp rx:      5 MB/s     4512 calls/s
 udp tx:     75 MB/s     1288 calls/s   1288 msg/s
 GRO frag list over UDP tunnel           exec of "iptables-save" failed: No such file or directory
 ./udpgro_fwd.sh: line 135: [: !=: unary operator expected
 exec of "iptables-save" failed: No such file or directory
 ./udpgro_fwd.sh: line 145: [: too many arguments
  ok
 GRO fwd over UDP tunnel                 exec of "iptables-save" failed: No such file or directory
 ./udpgro_fwd.sh: line 135: [: !=: unary operator expected
 exec of "iptables-save" failed: No such file or directory
 ./udpgro_fwd.sh: line 145: [: too many arguments
  ok

Before this patch, json is:
net.udpgro_fwd.sh.pass: 1

After this patch, json is:
net.udpgro_fwd.sh.IPv4.No_GRO.pass: 1
net.udpgro_fwd.sh.IPv4.GRO_frag_list.pass: 1
net.udpgro_fwd.sh.IPv4.GRO_fwd.pass: 1
net.udpgro_fwd.sh.IPv4.GRO_frag_list_over_UDP_tunnel.pass: 1 net.udpgro_fwd.sh.IPv4.GRO_fwd_over_UDP_tunnel.pass: 1 net.udpgro_fwd.sh.IPv6.No_GRO.pass: 1
net.udpgro_fwd.sh.IPv6.GRO_frag_list.pass: 1
net.udpgro_fwd.sh.IPv6.GRO_fwd.pass: 1
net.udpgro_fwd.sh.IPv6.GRO_frag_list_over_UDP_tunnel.pass: 1 net.udpgro_fwd.sh.IPv6.GRO_fwd_over_UDP_tunnel.pass: 1 net.udpgro_fwd.sh.pass: 1

Link: https://github.com/intel/lkp-tests/issues/209