### PR TITLE
amazon-linux: use same code as on fedora and centos

### DIFF
--- a/bin/setup-local
+++ b/bin/setup-local
@@ -134,7 +134,7 @@ def install_benchmarks(script, distro)
     case distro
     when 'debian', 'ubuntu'
       system "dpkg -i /tmp/#{pkg_name}.deb"
-    when 'fedora'
+    when 'fedora', 'amazon_linux'
       system "rpm -ivh --replacepkgs /tmp/#{pkg_name}/RPMS/#{pkg_name}.#{arch}.rpm"
     else
       puts "Just make /lkp/benchmarks/#{script}-#{arch}.cgz"

--- a/distro/adaptation-pkg/amazon_linux
+++ b/distro/adaptation-pkg/amazon_linux
@@ -1,1 +1,132 @@
-fedora
+aim7::
+aim9::
+analyze-suspend::
+blktests::
+blogbench::
+bpfcc-tools::
+bust-shm-exit::
+cassandra::
+chromeswap::
+cyclictest::
+dbench: tbench
+device-dax: ndctl
+eatmem: vm-scalability
+ebizzy::
+filebench::
+fileio::
+fio::
+fsmark::
+ftq::
+fwq::
+fxmark::
+hackbench::
+hwsim::
+igt::
+iozone::
+kbuild::
+ku-latency::
+kvm-unit-tests::
+leaking-addresses::
+libfdt-dev::
+libhugetlbfs::
+libhugetlbfs-test::
+liblz-dev: lzlib
+lib-micro::
+liboop-dev: liboop
+linkbench::
+linpack::
+lmbench3::
+ltp::
+lz4-test::
+makepkg::
+mce-log::
+mce-test::
+mcperf::
+mdadm-selftests::
+memtier::
+mongodb::
+ndctl::
+nepim::
+netperf::
+netpipe-lam: netpipe
+nvdimm: ndctl
+ocfs2test::
+oltp::
+openssl-speed::
+otc_ddt::
+packetdrill::
+pbzip2::
+pepc::
+perf::
+perf-bench-futex: perf
+perf-c2c: perf
+perf-event-tests::
+perf-mem: perf
+perf-node: perf
+perf-probe: perf
+perf-profile: perf
+perf-record-report: perf
+perf-report-srcline: perf
+perf-sanity-tests: perf
+perf-stat: perf
+pft::
+phpbench::
+piglit::
+plzip::
+pmbench::
+pmdk::
+pm-qa::
+pybench::
+postmark::
+qperf::
+reaim::
+redis-server::
+rocksdb::
+rt-tests::
+sar::
+schbench::
+simd-stress::
+sockperf::
+stream::
+stress-ng::
+stutter::
+swapin: vm-scalability
+sysbench-cpu::
+sysbench-memory::
+sysbench-mutex::
+sysbench-threads::
+tbench::
+thrulay::
+tinymembench::
+trace-cmd::
+trinity::
+trinity-static-i386::
+trinity-static-x86_64::
+turbostat::
+unixbench::
+vm-scalability::
+will-it-scale::
+xfstests::
+ycsb::
+avocado::
+daxctl::
+pmu-tools::
+autonuma-benchmark::
+pixz::
+mutilate::
+v4l2::
+energy: perf
+tlbflush::
+nvml::
+build-nvml: nvml
+nuttcp::
+adrestia::
+kernel-selftests::
+toplev: pmu-tools
+kvm-kernel-boot-test::
+vmem::
+phoronix-test-suite::
+bpftrace::
+kernbench::
+rt-app::
+coremark::

--- a/lkp-exec/install
+++ b/lkp-exec/install
@@ -172,7 +172,7 @@ verify_install() {
 	case $DISTRO in
 		debian|ubuntu)
 			[[ ! $(dpkg -V "$pkg" 2>&1) ]] || [[ ! $(dpkg -V "$pkg-lkp" 2>&1) ]];;
-		centos|fedora)
+		centos|fedora|amazon_linux)
 			[[ ! $(rpm -V "$pkg" 2>&1) ]] || [[ ! $(rpm -V "$pkg-lkp" 2>&1) ]];;
 		*)
 			return 1;;
@@ -264,7 +264,7 @@ build_install_benchmarks() {
 				return 1
 			}
 			;;
-		fedora)
+		fedora|amazon_linux)
 			BUILD_DIR=$(get_build_dir $script)
 			local rpm_pkg=$BUILD_DIR/$pkg_name/RPMS/$pkg_name.$arch.rpm
 			[ -f $rpm_pkg ] || return

--- a/pack/default
+++ b/pack/default
@@ -133,7 +133,7 @@ pack_pkg()
 	case $distro in
 		debian|ubuntu)
 			pack_deb ;;
-		fedora)
+		fedora|amazon_linux)
 			pack_rpm ;;
 		*)
 			pack ;;

--- a/sbin/pacman-LKP
+++ b/sbin/pacman-LKP
@@ -103,7 +103,7 @@ distro_pkg_format() {
 	case $DISTRO in
 		debian|ubuntu)
 			echo deb;;
-		fedora|centos)
+		fedora|centos|amazon_linux)
 			echo rpm;;
 		*)
 			echo other;;


### PR DESCRIPTION
Add amazon_linux distro to several places that have specialized code that deal with RPMs.