### PR TITLE
stats/kernel-selftests: add x86/sigreturn_32/64 test result process

### DIFF
--- a/spec/stats/kernel-selftests/x86-06
+++ b/spec/stats/kernel-selftests/x86-06
@@ -1,0 +1,30 @@
+# selftests: x86: sigreturn_32
+# [OK]	set_thread_area refused 16-bit data
+# [OK]	set_thread_area refused 16-bit data
+# [WARN]	Could not find 64-bit CS
+# [SKIP]	Code segment unavailable for 64-bit CS, 32-bit SS
+# [RUN]	Valid sigreturn: 32-bit CS (73), 32-bit SS (7b, GDT)
+# [OK]	all registers okay
+# [RUN]	Valid sigreturn: 16-bit CS (37), 32-bit SS (7b, GDT)
+# [OK]	all registers okay
+# [WARN]	Could not find 64-bit CS
+# [SKIP]	Code segment unavailable for 64-bit CS, 16-bit SS
+# [RUN]	Valid sigreturn: 32-bit CS (73), 16-bit SS (3f)
+# [OK]	all registers okay
+# [RUN]	Valid sigreturn: 16-bit CS (37), 16-bit SS (3f)
+# [OK]	all registers okay
+# [WARN]	Could not find 64-bit CS
+# [RUN]	32-bit CS (73), bogus SS (47)
+# [OK]	Got #IRET(0x0) (i.e. Illegal instruction)
+# [RUN]	16-bit CS (37), bogus SS (47)
+# [OK]	Got #IRET(0x0) (i.e. Illegal instruction)
+# [WARN]	Could not find 64-bit CS
+# [RUN]	32-bit CS (73), bogus SS (73)
+# [OK]	Got #IRET(0x0) (i.e. Illegal instruction)
+# [RUN]	16-bit CS (37), bogus SS (73)
+# [OK]	Got #IRET(0x0) (i.e. Illegal instruction)
+# [RUN]	32-bit CS (4f), bogus SS (7b)
+# [OK]	Got #IRET(0x0) (i.e. Illegal instruction)
+# [RUN]	32-bit CS (73), bogus SS (57)
+# [OK]	Got #IRET(0x0) (i.e. Illegal instruction)
+ok 6 selftests: x86: sigreturn_32

--- a/spec/stats/kernel-selftests/x86-06.yaml
+++ b/spec/stats/kernel-selftests/x86-06.yaml
@@ -1,0 +1,13 @@
+x86.sigreturn_32.Code_segment_unavailable_for_64-bit_CS_32-bit_SS.skip: 1
+x86.sigreturn_32.Valid_sigreturn_32-bit_CS_73_32-bit_SS_7b_GDT.pass: 1
+x86.sigreturn_32.Valid_sigreturn_16-bit_CS_37_32-bit_SS_7b_GDT.pass: 1
+x86.sigreturn_32.Code_segment_unavailable_for_64-bit_CS_16-bit_SS.skip: 1
+x86.sigreturn_32.Valid_sigreturn_32-bit_CS_73_16-bit_SS_3f.pass: 1
+x86.sigreturn_32.Valid_sigreturn_16-bit_CS_37_16-bit_SS_3f.pass: 1
+x86.sigreturn_32.32-bit_CS_73_bogus_SS_47.pass: 1
+x86.sigreturn_32.16-bit_CS_37_bogus_SS_47.pass: 1
+x86.sigreturn_32.32-bit_CS_73_bogus_SS_73.pass: 1
+x86.sigreturn_32.16-bit_CS_37_bogus_SS_73.pass: 1
+x86.sigreturn_32.32-bit_CS_4f_bogus_SS_7b.pass: 1
+x86.sigreturn_32.32-bit_CS_73_bogus_SS_57.pass: 1
+x86.sigreturn_32.pass: 1

--- a/stats/kernel-selftests
+++ b/stats/kernel-selftests
@@ -680,10 +680,11 @@ class X86Stater < Stater
     when /^# \[RUN\]\s+(.*)/
       # [RUN] SYSENTER with invalid state
       @runtest_case = $1
-    when /^# \[(OK|FAIL|SKIP)\]/
+    when /^# \[(OK|FAIL|SKIP)\]\s+(.*)/
       # [OK]  Seems okay
       # [SKIP]        Illegal instruction
       @result = $1
+      @subtest_case = $2
       if @runtest_case
         # [RUN] Fast syscall with TF cleared
         # [OK]  Nothing unexpected happened
@@ -693,6 +694,10 @@ class X86Stater < Stater
         # [OK]  Nothing unexpected happened
         stats.add "#{@test_prefix}.#{@runtest_case}", @result unless stats.key? "#{@test_prefix}.#{@runtest_case}"
         @runtest_case = nil
+      elsif @result =~ /SKIP/ && @subtest_case
+        # [SKIP]        Code segment unavailable for 64-bit CS, 32-bit SS
+        stats.add "#{@test_prefix}.#{@subtest_case}", @result unless stats.key? "#{@test_prefix}.#{@subtest_case}"
+        @subtest_case = nil
       end
     else
       super(line, stats)


### PR DESCRIPTION
For following output:
 selftests: x86: sigreturn_32
 [OK]  set_thread_area refused 16-bit data
 [OK]  set_thread_area refused 16-bit data
 [WARN]        Could not find 64-bit CS
 [SKIP]        Code segment unavailable for 64-bit CS, 32-bit SS
 [RUN] Valid sigreturn: 32-bit CS (73), 32-bit SS (7b, GDT)
 [OK]  all registers okay

Before this patch, json is:
x86.sigreturn_32.Valid_sigreturn_32-bit_CS_73_32-bit_SS_7b_GDT.pass: 1

After this patch, json is:
x86.sigreturn_32.Code_segment_unavailable_for_64-bit_CS_32-bit_SS.skip: 1 x86.sigreturn_32.Valid_sigreturn_32-bit_CS_73_32-bit_SS_7b_GDT.pass: 1