### PR TITLE
stats/kernel-selftests: add x86/unwind_vdso_32 test result process

### DIFF
--- a/spec/stats/kernel-selftests/x86-07
+++ b/spec/stats/kernel-selftests/x86-07
@@ -1,0 +1,40 @@
+# selftests: x86: unwind_vdso_32
+# 	AT_SYSINFO is 0xf7f3e540
+# [OK]	AT_SYSINFO maps to linux-gate.so.1, loaded at 0x0xf7f3e000
+# [RUN]	Set TF and check a fast syscall
+# 	In vsyscall at 0xf7f3e540, returning to 0xf7dfd0c7
+# 	SIGTRAP at 0xf7f3e540
+# 	  0xf7f3e540
+# 	  0xf7dfd0c7
+# [OK]	  NR = 20, args = 1, 2, 3, 4, 5, 6
+# 	SIGTRAP at 0xf7f3e541
+# 	  0xf7f3e541
+# 	  0xf7dfd0c7
+# [OK]	  NR = 20, args = 1, 2, 3, 4, 5, 6
+# 	SIGTRAP at 0xf7f3e542
+# 	  0xf7f3e542
+# 	  0xf7dfd0c7
+# [OK]	  NR = 20, args = 1, 2, 3, 4, 5, 6
+# 	SIGTRAP at 0xf7f3e543
+# 	  0xf7f3e543
+# 	  0xf7dfd0c7
+# [OK]	  NR = 20, args = 1, 2, 3, 4, 5, 6
+# 	SIGTRAP at 0xf7f3e545
+# 	  0xf7f3e545
+# 	  0xf7dfd0c7
+# [OK]	  NR = 20, args = 1, 2, 3, 4, 5, 6
+# 	SIGTRAP at 0xf7f3e54a
+# 	  0xf7f3e54a
+# 	  0xf7dfd0c7
+# [OK]	  NR = 3428, args = 1, 2, 3, 4, 5, 6
+# 	SIGTRAP at 0xf7f3e54b
+# 	  0xf7f3e54b
+# 	  0xf7dfd0c7
+# [OK]	  NR = 3428, args = 1, 2, 3, 4, 5, 6
+# 	SIGTRAP at 0xf7f3e54c
+# 	  0xf7f3e54c
+# 	  0xf7dfd0c7
+# [OK]	  NR = 3428, args = 1, 2, 3, 4, 5, 6
+# 	Vsyscall is done
+# [OK]	All is well
+ok 16 selftests: x86: unwind_vdso_32

--- a/spec/stats/kernel-selftests/x86-07.yaml
+++ b/spec/stats/kernel-selftests/x86-07.yaml
@@ -1,0 +1,2 @@
+x86.unwind_vdso_32.Set_TF_and_check_a_fast_syscall.pass: 1
+x86.unwind_vdso_32.pass: 1

--- a/spec/stats/kernel-selftests/x86-08
+++ b/spec/stats/kernel-selftests/x86-08
@@ -1,0 +1,37 @@
+# selftests: x86: unwind_vdso_32
+# 	AT_SYSINFO is 0xf7f3e540
+# [OK]	AT_SYSINFO maps to linux-gate.so.1, loaded at 0x0xf7f3e000
+# [RUN]	Set TF and check a fast syscall
+# 	In vsyscall at 0xf7f3e540, returning to 0xf7dfd0c7
+# 	SIGTRAP at 0xf7f3e540
+# 	  0xf7f3e540
+# 	  0xf7dfd0c7
+# [OK]	  NR = 20, args = 1, 2, 3, 4, 5, 6
+# 	SIGTRAP at 0xf7f3e541
+# 	  0xf7f3e541
+# 	  0xf7dfd0c7
+# [OK]	  NR = 20, args = 1, 2, 3, 4, 5, 6
+# 	SIGTRAP at 0xf7f3e542
+# 	  0xf7f3e542
+# 	  0xf7dfd0c7
+# [OK]	  NR = 20, args = 1, 2, 3, 4, 5, 6
+# 	SIGTRAP at 0xf7f3e543
+# 	  0xf7f3e543
+# 	  0xf7dfd0c7
+# [OK]	  NR = 20, args = 1, 2, 3, 4, 5, 6
+# 	SIGTRAP at 0xf7f3e545
+# 	  0xf7f3e545
+# 	  0xf7dfd0c7
+# [OK]	  NR = 20, args = 1, 2, 3, 4, 5, 6
+# 	SIGTRAP at 0xf7f3e54a
+# 	  0xf7f3e54a
+# 	  0xf7dfd0c7
+# [OK]	  NR = 3428, args = 1, 2, 3, 4, 5, 6
+# 	SIGTRAP at 0xf7f3e54b
+# 	  0xf7f3e54b
+# 	  0xf7dfd0c7
+# [OK]	  NR = 3428, args = 1, 2, 3, 4, 5, 6
+# 	SIGTRAP at 0xf7f3e54c
+# 	  0xf7f3e54c
+# 	  0xf7dfd0c7
+# [FAIL]  NR = 3428, args = 1, 2, 3, 4, 5, 6

--- a/spec/stats/kernel-selftests/x86-08.yaml
+++ b/spec/stats/kernel-selftests/x86-08.yaml
@@ -1,0 +1,1 @@
+x86.unwind_vdso_32.Set_TF_and_check_a_fast_syscall.fail: 1

--- a/stats/kernel-selftests
+++ b/stats/kernel-selftests
@@ -685,7 +685,13 @@ class X86Stater < Stater
       # [SKIP]        Illegal instruction
       @result = $1
       @subtest_case = $2
-      if @runtest_case
+      if @test_script == 'unwind_vdso_32' && @result == 'OK' && @runtest_case
+        # [OK]  All is well
+        if @subtest_case =~ /All is well/
+          stats.add "#{@test_prefix}.#{@runtest_case}", @result
+          @runtest_case = nil
+        end
+      elsif @runtest_case
         # [RUN] Fast syscall with TF cleared
         # [OK]  Nothing unexpected happened
         # [RUN] Set TF and check SYSENTER


### PR DESCRIPTION
For following output:
 selftests: x86: unwind_vdso_32
       AT_SYSINFO is 0xf7f3e540
 [OK]  AT_SYSINFO maps to linux-gate.so.1, loaded at 0x0xf7f3e000
 [RUN] Set TF and check a fast syscall
       In vsyscall at 0xf7f3e540, returning to 0xf7dfd0c7
       SIGTRAP at 0xf7f3e540
         0xf7f3e540
         0xf7dfd0c7
 [OK]    NR = 20, args = 1, 2, 3, 4, 5, 6
       SIGTRAP at 0xf7f3e541
         0xf7f3e541
         0xf7dfd0c7
 [FAIL]  NR = 3428, args = 1, 2, 3, 4, 5, 6

Before this patch, json is:
x86.unwind_vdso_32.Set_TF_and_check_a_fast_syscall.pass: 1

After this patch, json is:
x86.unwind_vdso_32.Set_TF_and_check_a_fast_syscall.fail: 1

Link: https://github.com/intel/lkp-tests/issues/207