### PR TITLE
stats/kernel-selftests: add x86/check_initial_reg_state_32/64 test re…

### DIFF
--- a/spec/stats/kernel-selftests/x86-09
+++ b/spec/stats/kernel-selftests/x86-09
@@ -1,0 +1,8 @@
+# selftests: x86: check_initial_reg_state_32
+# [OK]	All GPRs except SP are 0
+# [OK]	FLAGS is 0x202
+ok 5 selftests: x86: check_initial_reg_state_32
+# selftests: x86: check_initial_reg_state_64
+# [OK]	All GPRs except SP are 0
+# [OK]	FLAGS is 0x202
+ok 27 selftests: x86: check_initial_reg_state_64

--- a/spec/stats/kernel-selftests/x86-09.yaml
+++ b/spec/stats/kernel-selftests/x86-09.yaml
@@ -1,0 +1,6 @@
+x86.check_initial_reg_state_32.All_GPRs_except_SP_are_0.pass: 1
+x86.check_initial_reg_state_32.FLAGS_is_0x202.pass: 1
+x86.check_initial_reg_state_32.pass: 1
+x86.check_initial_reg_state_64.All_GPRs_except_SP_are_0.pass: 1
+x86.check_initial_reg_state_64.FLAGS_is_0x202.pass: 1
+x86.check_initial_reg_state_64.pass: 1

--- a/stats/kernel-selftests
+++ b/stats/kernel-selftests
@@ -691,6 +691,8 @@ class X86Stater < Stater
           stats.add "#{@test_prefix}.#{@runtest_case}", @result
           @runtest_case = nil
         end
+      elsif @test_script =~ /check_initial_reg_state/
+        stats.add "#{@test_prefix}.#{@subtest_case}", @result
       elsif @runtest_case
         # [RUN] Fast syscall with TF cleared
         # [OK]  Nothing unexpected happened


### PR DESCRIPTION
…sult process

For following output:
 selftests: x86: check_initial_reg_state_32
 [OK]  All GPRs except SP are 0
 [OK]  FLAGS is 0x202
ok 5 selftests: x86: check_initial_reg_state_32
 selftests: x86: check_initial_reg_state_64
 [OK]  All GPRs except SP are 0
 [OK]  FLAGS is 0x202
ok 27 selftests: x86: check_initial_reg_state_64

Before this patch, json is:
x86.check_initial_reg_state_32.pass: 1
x86.check_initial_reg_state_64.pass: 1

After this patch, json is:
x86.check_initial_reg_state_32.All_GPRs_except_SP_are_0.pass: 1 x86.check_initial_reg_state_32.FLAGS_is_0x202.pass: 1 x86.check_initial_reg_state_32.pass: 1
x86.check_initial_reg_state_64.All_GPRs_except_SP_are_0.pass: 1 x86.check_initial_reg_state_64.FLAGS_is_0x202.pass: 1 x86.check_initial_reg_state_64.pass: 1

Link: https://github.com/intel/lkp-tests/issues/207