### PR TITLE
fix port mismatch between redis server and redis benchmark. fix resul…

### DIFF
--- a/daemon/redis-server
+++ b/daemon/redis-server
@@ -22,7 +22,7 @@ parse_numa_node_binding "$redis_cpu_node_bind" "$redis_mem_node_bind"
 for i in $(seq 1 "${nr_processes}"); do
 	port=$((6379+i+instance_id))
 	numa_bind=$(numa_node_binding "$i")
-	log_eval "$numa_bind $redis_server --port $port &"
+	log_eval "$numa_bind $redis_server --port $port --save \"\" &"
 	bg_pids="$bg_pids $!"
 done
 

--- a/pkg/redis-server/PKGBUILD
+++ b/pkg/redis-server/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=redis
-pkgver=6.2.8
+pkgver=7.0.9
 pkgrel=0
 arch=('i386' 'x86_64' 'aarch64')
 url="https://redis.io"

--- a/stats/redis
+++ b/stats/redis
@@ -37,7 +37,7 @@ $stdin.each_line do |line|
   when /====== GET ======$/
     is_set = false
     proc_get_latencies = []
-  when /^(\d+\.\d+) requests per second$/
+  when /  throughput summary: (\d+\.\d+) requests per second$/
     if is_set
       set_sum += $1.to_f
       set_num += 1

--- a/tests/redis
+++ b/tests/redis
@@ -51,7 +51,7 @@ parse_numa_node_binding "$cpu_node_bind" "$mem_node_bind"
 
 for i in $(seq 1 "$nr_processes")
 do
-	port=$((6379+i))
+	port=$((6380+i))
 	numa_bind=$(numa_node_binding "$i")
 	log_test $numa_bind redis-benchmark $opt -p "$port" > "$redis_dir/redis.$i" &
 done


### PR DESCRIPTION
Redis test case fixes: 
- fixed port mismatch between redis server and redis benchmark
- fixed stats parsing
- disable RDB

Upgrade to latest version of Redis