### PR TITLE
Added support to run perf numa mem bench with custom params

### DIFF
--- a/jobs/perf-bench-numa-mem.yaml
+++ b/jobs/perf-bench-numa-mem.yaml
@@ -2,7 +2,9 @@ suite: perf-bench-numa-mem
 testcase: perf-bench-numa-mem
 category: benchmark
 
+nr_processes: 100%
 nr_threads: 2t
 
 perf-bench-numa-mem:
   mem_proc: 300M
+  extra_params:

--- a/spec/stats/perf-bench-numa-mem/01
+++ b/spec/stats/perf-bench-numa-mem/01
@@ -1,0 +1,31 @@
+2023-04-10 10:53:01 perf bench numa mem -p 128 -t 2 -m -0 -P 300
+# Running 'numa/mem' benchmark:
+
+ # Running main, "perf bench numa numa-mem -p 128 -t 2 -m -0 -P 300"
+#
+#
+
+ ###
+ # 256 tasks will execute (on 2 nodes, 128 CPUs):
+ #         -1x     1MB global  shared mem operations
+ #         -1x   300MB process shared mem operations
+ #         -1x     0MB thread  local  mem operations
+ ###
+
+ ###
+ #
+ # Startup synchronization: ... threads initialized in 1.086025 seconds.
+ #
+
+ ###
+
+ main,                                    6.801, secs,           NUMA-convergence-latency
+ main,                                    6.801, secs,           runtime-max/thread
+ main,                                    4.000, secs,           runtime-min/thread
+ main,                                    5.650, secs,           runtime-avg/thread
+ main,                                   20.594, %,              spread-runtime/thread
+ main,                                    0.836, GB,             data/thread
+ main,                                  213.991, GB,             data-total
+ main,                                    8.136, nsecs,          runtime/byte/thread
+ main,                                    0.123, GB/sec,         thread-speed
+ main,                                   31.463, GB/sec,         total-speed

--- a/spec/stats/perf-bench-numa-mem/01.yaml
+++ b/spec/stats/perf-bench-numa-mem/01.yaml
@@ -1,0 +1,10 @@
+secs_latency: 6.801
+secs_slowest: 6.801
+secs_fastest: 4.000
+secs_avg: 5.650
+max_avg_diff: 20.594
+GB_per_thread: 0.836
+GB_total: 213.991
+nsecs_byte_thread: 8.136
+GB_sec_thread: 0.123
+GB_sec_total: 31.463

--- a/tests/perf-bench-numa-mem
+++ b/tests/perf-bench-numa-mem
@@ -1,6 +1,8 @@
 #!/bin/sh
+# - nr_processes
 # - nr_threads
 # - mem_proc
+# - extra_params
 
 ## perf began as a tool for using the performance counters
 ## subsystem in Linux, and has had various enhancements
@@ -9,8 +11,10 @@
 . $LKP_SRC/lib/unit.sh
 . $LKP_SRC/lib/reproduce-log.sh
 
+[ -n "$nr_processes" ] || nr_processes=$nr_cpu
+
 mb_proc=$(to_mb $mem_proc)
 
 log_cmd numactl --hard || die "Test needs available numa"
 
-log_cmd perf bench numa mem -p $nr_cpu -t $nr_threads -m -0 -P $mb_proc
+log_cmd perf bench numa mem -p $nr_processes -t $nr_threads -m -0 -P $mb_proc $extra_params


### PR DESCRIPTION
Currently perf numa mem bench runs with default params. This change adds support to change the number of processes and add extra set of parameters.
Added test for perf numa mem bench in spec/stats.