### PR TITLE
docker: support ubuntu:22.04

### DIFF
--- a/distro/adaptation/ubuntu-22.04
+++ b/distro/adaptation/ubuntu-22.04
@@ -7,3 +7,4 @@ libx32gcc1: libx32gcc-s1
 lib32gcc-dev: lib32gcc-12-dev
 libx32gcc-dev: libx32gcc-12-dev
 libipsec-mb0: libipsec-mb1
+libpython3.9: libpython3.10

--- a/docker/ubuntu/jammy/Dockerfile
+++ b/docker/ubuntu/jammy/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:jammy
+
+# lkp install generates hosts/$HOSTNAME during create_host_config. Here it requires
+# user to pass hostname arg to specify a consistent name instead of the container
+# hostname when building the image.
+ARG hostname=lkp-docker
+ENV HOSTNAME=${hostname}
+
+WORKDIR /lkp/lkp-tests
+
+COPY . ./
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+    # linux-tools-generic contains perf and turbostat
+    linux-tools-generic \
+    make \
+    # procps installs vmstat, sysctl, etc to partially persistent commonly used dependencies
+    procps \
+    sudo && \
+    make install && \
+    lkp install && \
+    # replace the turbostat and perf wrappers in /usr/bin with the ones installed from linux-tools-generic
+    # because the wrappers have very restrictive kernel version dependency checks
+    ln -sf $(find /usr/lib -name turbostat | head -n 1) /usr/bin/turbostat && \
+    ln -sf $(find /usr/lib -name perf | head -n 1) /usr/bin/perf
+
+ENTRYPOINT ["bash", "-c", "sleep infinity"]


### PR DESCRIPTION
Create new Dockerfile in docker/ubuntu/jammy to add support for ubuntu:22.04 image=ubuntu/jammy

Closes #267