### PR TITLE
repo: Update contact email for Mat Martineau

### DIFF
--- a/repo/linux/martineau
+++ b/repo/linux/martineau
@@ -1,4 +1,4 @@
 url: https://git.kernel.org/pub/scm/linux/kernel/git/martineau/linux.git
-owner: Mat Martineau <mathew.j.martineau@linux.intel.com>
+owner: Mat Martineau <martineau@kernel.org>
 notify_build_success_branch: .*
-mail_cc: mathew.j.martineau@linux.intel.com
+mail_cc: martineau@kernel.org

--- a/repo/linux/mptcp
+++ b/repo/linux/mptcp
@@ -7,5 +7,5 @@ branch_denylist: .*
 mail_cc:
 - mptcp@lists.linux.dev
 owner:
-- Mat Martineau <mathew.j.martineau@linux.intel.com>
+- Mat Martineau <martineau@kernel.org>
 - Matthieu Baerts <matthieu.baerts@tessares.net>


### PR DESCRIPTION
I'm still using my git.kernel.org repo and am maintaining MPTCP, but my old email address doesn't work any more. Shift over to my kernel.org email.