### PR TITLE
repo/linux/song-md: notify_build_success_branch only on md-.* branches

### DIFF
--- a/repo/linux/song-md
+++ b/repo/linux/song-md
@@ -6,6 +6,6 @@ subsystems:
 - raid5-cache
 - raid5
 - md-cluster
-notify_build_success_branch: .*
+notify_build_success_branch: md-.*
 mail_to: Song Liu <song@kernel.org>
 mail_cc: linux-raid@vger.kernel.org


### PR DESCRIPTION
Let's not report build failures for other branches.