### PR TITLE
repo/linux: replace maintainer of Linux FireWire subsystem

### DIFF
--- a/repo/linux/ieee1394-linux1394
+++ b/repo/linux/ieee1394-linux1394
@@ -1,5 +1,7 @@
 url: https://git.kernel.org/pub/scm/linux/kernel/git/ieee1394/linux1394.git
-integration_testing_branches: for-next
+integration_testing_branches
+- for-next
+- for-linus
 mail_cc: linux1394-devel@lists.sourceforge.net
 owner:
 - Takashi Sakamoto <o-takashi@sakamocchi.jp>
@@ -8,3 +10,4 @@ subsystems:
 - firewire
 - sbp2
 - ohci
+branch_denylist: master

--- a/repo/linux/ieee1394-linux1394
+++ b/repo/linux/ieee1394-linux1394
@@ -1,7 +1,9 @@
 url: https://git.kernel.org/pub/scm/linux/kernel/git/ieee1394/linux1394.git
 integration_testing_branches: for-next
 mail_cc: linux1394-devel@lists.sourceforge.net
-owner: Stefan Richter <stefanr@s5r6.in-berlin.de>
+owner:
+- Takashi Sakamoto <o-takashi@sakamocchi.jp>
+- Takashi Sakamoto <takaswie@kernel.org>
 subsystems:
 - firewire
 - sbp2


### PR DESCRIPTION
At Linux kernel v6.4, the maintainer of Linux FireWire subsystem was replaced. This pull request brings changes related to it.