### PR TITLE
Fedora adapt

### DIFF
--- a/bin/lkp-setup-rootfs
+++ b/bin/lkp-setup-rootfs
@@ -43,12 +43,12 @@ boot_init || {
 # FIXME: need to consider more factors, such as cmdline, boot_parameter
 job_does_not_need_reboot()
 {
-	grep -q "^do_not_reboot: 1$" $job && {
+	grep -q '^do_not_reboot: 1$' $job && {
 		echo "LKP: [do_not_reboot] start a new job without rebooting"
 		return 0
 	}
 
-	grep -q "^do_not_reboot_for_same_kernel: 1$" $job &&
+	grep -q '^do_not_reboot_for_same_kernel: 1$' $job &&
 	is_same_kernel_and_rootfs && is_same_testcase && is_same_bp_memmap && {
 		echo "LKP: [do_not_reboot_for_same_kernel] start a new job without rebooting"
 		return 0
@@ -59,12 +59,12 @@ job_does_not_need_reboot()
 
 job_force_reboot()
 {
-	grep -q "^force_reboot: \+1$" $job
+	grep -q '^force_reboot: \+1$' $job
 }
 
 reboot_for_next_job()
 {
-	grep -q "^reboot_for_next_job: \+1$" $job
+	grep -q '^reboot_for_next_job: \+1$' $job
 }
 
 start_reboot_watchdog()

--- a/lib/yaml.rb
+++ b/lib/yaml.rb
@@ -27,7 +27,11 @@ def load_yaml(file, template_context = nil)
   yaml = expand_yaml_template(yaml, file, template_context) if template_context
 
   begin
-    result = YAML.load yaml
+    result = if Psych::VERSION > '4.0'
+               YAML.unsafe_load(yaml)
+             else
+               YAML.load(yaml)
+             end
   rescue Psych::SyntaxError => e
     log_debug "failed to parse file #{file} | #{e}"
     raise


### PR DESCRIPTION
2 patches here:

1- use YAML.unsafe_load to avoid ruby 3.2 / Psych 4 error

    in `find': Tried to load unspecified class: Time (Psych::DisallowedClass)
            from /usr/share/gems/gems/psych-5.0.1/lib/psych/class_loader.rb:28:in `load'

2- use single-quotes around grep 'pattern' since no variable interpolation is done.
Maybe wrong wrt escape-backslash, I had no success proving it either way.