### PR TITLE
repo: update contact email for Matthieu Baerts

### DIFF
--- a/repo/linux/matttbe-net-next
+++ b/repo/linux/matttbe-net-next
@@ -1,4 +1,4 @@
 url: https://git.kernel.org/pub/scm/linux/kernel/git/matttbe/net-next.git
-owner: Matthieu Baerts <matthieu.baerts@tessares.net>
+owner: Matthieu Baerts <matttbe@kernel.org>
 notify_build_success_branch: .*
-mail_cc: matthieu.baerts@tessares.net
+mail_cc: matttbe@kernel.org

--- a/repo/linux/mptcp
+++ b/repo/linux/mptcp
@@ -8,4 +8,4 @@ mail_cc:
 - mptcp@lists.linux.dev
 owner:
 - Mat Martineau <martineau@kernel.org>
-- Matthieu Baerts <matthieu.baerts@tessares.net>
+- Matthieu Baerts <matttbe@kernel.org>


### PR DESCRIPTION
My other email address will bounce by the end of the year.

This email address is soon going to be updated in the `MAINTAINERS` file. For more details:

https://lore.kernel.org/netdev/20231004-send-net-20231004-v1-3-28de4ac663ae@kernel.org/

cc: @mjmartineau