### PR TITLE
Update rt-tests version

### DIFF
--- a/pkg/rt-tests/PKGBUILD
+++ b/pkg/rt-tests/PKGBUILD
@@ -1,12 +1,12 @@
 pkgname=rt-tests
-pkgver=2.5
+pkgver=2.6
 pkgrel=0
 pkgdesc="Suite of real-time tests - cyclictest, hwlatdetect, pip_stress, pi_stress, pmqtest, ptsematest, rt-migrate-test, sendme, signaltest, sigwaittest, svsematest"
 arch=('i386' 'x86_64' 'aarch64')
 url="https://git.kernel.org/cgit/utils/rt-tests/rt-tests.git/"
 license=('GPL')
 source=("https://www.kernel.org/pub/linux/utils/rt-tests/rt-tests-$pkgver.tar.gz")
-md5sums=('8728ed02282ba065ac3ca2f36a908256')
+md5sums=('1034236660c2be3f8b6b1a9cdfd3bc7f')
 
 build() {
         cd "$srcdir/$pkgname-$pkgver"

--- a/programs/hackbench/pkg/PKGBUILD
+++ b/programs/hackbench/pkg/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=hackbench
-pkgver=2.5
-pkgrel=1
+pkgver=2.6
+pkgrel=0
 arch=('i386' 'x86_64' 'riscv64' 'aarch64')
 url="https://www.kernel.org/pub/linux/utils/rt-tests"
 license=('GPL')


### PR DESCRIPTION
hackbench install fails currently as rt-tests
package is updated upstream. Fixing the version.