### PR TITLE
distro/adaptation: fix hackbench package dependencies of centos 7

### DIFF
--- a/distro/adaptation/centos-7
+++ b/distro/adaptation/centos-7
@@ -1,0 +1,13 @@
+default-jdk:
+g++: gcc-c++
+ibtraceevent-dev:
+libclang-dev: clang-devel
+libmpfr6: mpfr
+libpfm4: libpfm
+libpfm4-dev: libpfm-devel
+libpython3.9: python3-libs
+libtraceevent1:
+libtraceevent-dev:
+llvm-dev: llvm-devel
+python-dev: python-devel
+rng-tools5: rng-tools


### PR DESCRIPTION
hackbench: centos stream 9: no packages available when installing dependencies