### PR TITLE
distro/adaptation: fix hackbench package dependencies mapping of centos stream 9

### DIFF
--- a/distro/adaptation/centos-9
+++ b/distro/adaptation/centos-9
@@ -1,0 +1,14 @@
+default-jdk: 
+libclang-dev: clang-devel
+libmpfr6: mpfr
+libpfm4: libpfm
+libpfm4-dev: libpfm-devel
+libpython3.9: python3-libs
+libtraceevent1: libtraceevent
+libtraceevent-dev: libtraceevent-devel
+llvm-dev: llvm-devel
+python-dev: 
+python: python3
+rng-tools5: rng-tools
+python3: python3 
+libpython2.7: python3-libs


### PR DESCRIPTION
hackbench: install the remaining dependencies for the splited job, no packages available. fix for the following error:
[root@localhost lkp-tests]# lkp install ./hackbench-socket-8-threads-100%.yaml ......
未找到匹配的参数: default-jdk
未找到匹配的参数: libclang-dev
未找到匹配的参数: libmpfr6
未找到匹配的参数: libpfm4
未找到匹配的参数: libpfm4-dev
未找到匹配的参数: libpython3.9
未找到匹配的参数: libtraceevent1
未找到匹配的参数: libtraceevent-dev
未找到匹配的参数: llvm-dev
未找到匹配的参数: platform-python-devel.x86_64
未找到匹配的参数: python2-libs
未找到匹配的参数: python34
未找到匹配的参数: rng-tools5
未找到匹配的参数: python2
错误：没有任何匹配: default-jdk libclang-dev libmpfr6 libpfm4 libpfm4-dev libpython3.9 libtraceevent1 libtraceevent-dev llvm-dev platform-python-devel.x86_64 python2-libs python34 rng-tools5 python2 Cannot install some packages of perf-c2c depends