### PR TITLE
jimc: add mail-cc for a collaborator

### DIFF
--- a/repo/linux/jimc
+++ b/repo/linux/jimc
@@ -1,5 +1,5 @@
 url: https://github.com/jimc/linux.git
 owner: Jim Cromie <jim.cromie@gmail.com>
-mail_to: Jim Cromie <jim.cromie@gmail.com>
+mail_to: Jim Cromie <jim.cromie@gmail.com>, Lukasz Bartosik <lb@semihalf.com>
 private_report_branch: .*
 notify_build_success_branch: .*


### PR DESCRIPTION
Some of my branches are clones of Lukasz, somewhere in: https://chromium.googlesource.com/chromiumos/third_party/kernel

I'd like to not spam him with every branch I might push,

I've "noted" that with a trailing "# branch-match-pattern" on the mail-cc line, 
in case that can be made to operate (with some infrastructure patch?).