### PR TITLE
distro/adaptation: fix will-it-scale-part1 package dependencies mapping of centos 9

### DIFF
--- a/distro/adaptation/centos-9
+++ b/distro/adaptation/centos-9
@@ -8,6 +8,7 @@ libtraceevent1: libtraceevent
 libtraceevent-dev: libtraceevent-devel
 llvm-dev: llvm-devel
 python-dev: 
+python-minimal: python3
 python: python3
 rng-tools5: rng-tools
 python3: python3 


### PR DESCRIPTION
will-it-scale-part1: install the remaining dependencies for the splited job, no packages available. fix for the following error: [root@localhost jobs]# lkp install ./will-it-scale-part1-thread-16-brk1.yaml ......
未找到匹配的参数: python2
软件包 zlib-devel-1.2.11-41.el9.x86_64 已安装。
错误：没有任何匹配: python2
Cannot install some packages of will-it-scale depends