### PR TITLE
distro/adaptation: fix stress-ng-class-cpu-cache package dependencies mapping of centos 9

### DIFF
--- a/distro/adaptation/centos-9
+++ b/distro/adaptation/centos-9
@@ -6,6 +6,9 @@ libpfm4-dev: libpfm-devel
 libpython3.9: python3-libs
 libtraceevent1: libtraceevent
 libtraceevent-dev: libtraceevent-devel
+libipsec-mb0: 
+libjudydebian1: Judy
+libjudy-dev: Judy-devel
 llvm-dev: llvm-devel
 python-dev: 
 python-minimal: python3


### PR DESCRIPTION
stress-ng-class-cpu-cache: install the remaining dependencies for the splited job, no packages available. fix for the following error: [root@localhost jobs]# lkp install ./stress-ng-class-cpu-cache-cpu-cache-100%-lockbus-60s.yaml ......
未找到匹配的参数: libipsec-mb0
未找到匹配的参数: libjudydebian1
未找到匹配的参数: libjudy-dev
错误：没有任何匹配: libipsec-mb0 libjudydebian1 libjudy-dev Cannot install some packages of stress-ng depends