### PR TITLE
Jag/0day update

### DIFF
--- a/repo/linux/joel-granados
+++ b/repo/linux/joel-granados
@@ -1,1 +1,3 @@
 url: https://git.kernel.org/pub/scm/linux/kernel/git/joel.granados/linux.git
+owner: Joel Granados <j.granados@samsung.com>
+notify_build_success_branch: .*

--- a/repo/linux/joelgranados
+++ b/repo/linux/joelgranados
@@ -1,4 +1,0 @@
-url: https://github.com/Joelgranados/linux.git
-owner: Joel Granados <j.granados@samsung.com>
-notify_build_success_branch: .*
-branch_allowlist: .*for-0day

--- a/repo/linux/sysctl
+++ b/repo/linux/sysctl
@@ -1,0 +1,6 @@
+url: https://git.kernel.org/pub/scm/linux/kernel/git/sysctl/sysctl.git
+git_am_branch: sysctl-next
+owner: Joel Granados <j.granados@samsung.com>
+maintained_subsystems:
+- PROC SYSCTL
+notify_build_success_branch: .*


### PR DESCRIPTION
1. Move all Joel Granados' stuff to the linux repo in kernel.org.
2. Add testing for sysctl shared repository