### PR TITLE
lkp-exec/install: add OS version check and mirror source for centos

### DIFF
--- a/lkp-exec/install
+++ b/lkp-exec/install
@@ -351,10 +351,30 @@ install_base_support()
 	create_host_config
 }
 
+enable_centos_source(){
+    if ! yum list installed | grep -q yum-utils; then
+        yum install -y yum-utils 
+    fi
+
+    if [ "$_system_version" = 9 ]; then
+	echo "enable source crb"
+        dnf config-manager --set-enabled crb
+    elif [ "$_system_version" = 8 ]; then
+	echo "enable source powertools"
+        dnf config-manager --set-enabled powertools
+    fi
+
+}
+
 . $LKP_SRC/lib/install.sh
 
 detect_system
 distro=$_system_name_lowercase
+
+echo "distro=$distro"
+echo "version=$_system_version"
+
+[ "$distro" = "centos" ] && enable_centos_source
 
 DISTRO=$distro
 export DISTRO


### PR DESCRIPTION
fix for the following error:
[root@localhost lkp-tests]# lkp install
Use: /root/lkp-tests/distro/installer/centos install bc gawk gzip kmod numactl rsync time which automake bison bsdtar bzip2 ca-certificates cpio fakeroot flex gcc git glibc-devel glibc-static glibc-devel.i686 glibc-static.i686 libtool make make automake gcc gcc-c++ kernel-devel rpm-build openssl openssl-devel patch perf perl-IPC-Run rsync ruby ruby-devel wget ...... 软件包 git-2.39.3-1.el9.x86_64 已安装。
软件包 glibc-devel-2.34-95.el9.x86_64 已安装。
未找到匹配的参数: glibc-static
未找到匹配的参数: glibc-static.i686
软件包 libtool-2.4.6-45.el9.x86_64 已安装。
......
软件包 openssl-1:3.0.7-25.el9.x86_64 已安装。
未找到匹配的参数: perl-IPC-Run
软件包 wget-1.21.1-7.el9.x86_64 已安装。
错误：没有任何匹配: glibc-static glibc-static.i686 perl-IPC-Run Cannot install some packages of lkp depends