### PR TITLE
repo/linux: add mwalle

### DIFF
--- a/repo/linux/mwalle
+++ b/repo/linux/mwalle
@@ -1,0 +1,5 @@
+url: https://git.kernel.org/pub/scm/linux/kernel/git/mwalle/linux.git
+owner: Michael Walle <mwalle@kernel.org>
+mail_to: Michael Walle <mwalle@kernel.org>
+notify_build_success_branch: .*
+private_report_branch: .*


### PR DESCRIPTION
Add Michael Walles's mwalle/linux kernel.org repo.