### PR TITLE
distro/adaption: update the package mapping of debian-12

### DIFF
--- a/distro/adaptation/debian-12
+++ b/distro/adaptation/debian-12
@@ -46,3 +46,14 @@ libpython3: libpython3.11
 gcc: gcc-12
 libglut3: libglut3.12
 libgsl: libgsl27
+python2:
+qemu: 
+qt5-default: qtbase5-dev
+mcelog: rasdaemon
+libldap-2.4-2: libldap-2.5-0
+cython: 
+dh-systemd: debhelper
+libevent-2.1-6: libevent-2.1-7
+libhwloc5: libhwloc15
+libssl1.1: libssl3
+python-tox: tox


### PR DESCRIPTION
fix for the following error:
root@48d9c5df9663:~/lkp-tests# ./tools/test-packages.sh
arch=x86_64, distro=debian, _system_version=12
/root/lkp-tests/distro/installer/debian
Hit:1 http://linux-ftp.sh.intel.com/pub/mirrors/debian bookworm InRelease
Get:2 http://linux-ftp.sh.intel.com/pub/mirrors/debian bookworm/main i386 Packages [8679 kB]
Fetched 8679 kB in 2s (4884 kB/s)
Reading package lists... Done
Reading package lists...
Building dependency tree...
Reading state information...
Package python2 is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  dh-python

Package qemu is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

Package mcelog is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

Package libldap-2.4-2 is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  libldap-common

Package cython is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

Package qt5-default is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'cython' has no installation candidate
E: Unable to locate package dh-systemd
E: Unable to locate package libbabeltrace-devbinutils-dev
E: Unable to locate package libevent-2.1-6
E: Couldn't find any package by glob 'libevent-2.1-6'
E: Couldn't find any package by regex 'libevent-2.1-6'
E: Unable to locate package libhwloc5
E: Package 'libldap-2.4-2' has no installation candidate
E: Unable to locate package libssl1.1
E: Couldn't find any package by glob 'libssl1.1'
E: Couldn't find any package by regex 'libssl1.1'
E: Package 'mcelog' has no installation candidate
E: Package 'python2' has no installation candidate
E: Unable to locate package python3-tox
E: Package 'qemu' has no installation candidate
E: Package 'qt5-default' has no installation candidate