### PR TITLE
Update unixbench dependency on ubuntu

### DIFF
--- a/distro/adaptation/ubuntu
+++ b/distro/adaptation/ubuntu
@@ -25,3 +25,5 @@ nasm: nasm
 btrfs-tools: btrfs-progs
 gtk3: gir1.2-gtk-3.0
 libjpeg62-turbo: libjpeg-turbo8
+libglut3: freeglut3
+libglut-dev: freeglut3-dev  


### PR DESCRIPTION
Currently unixbench install fails on
Ubuntu 22.04.x throwing below error:
 E: Unable to locate package libglut3
 E: Unable to locate package libglut-dev
This commit updates those package dependency.