### PR TITLE
Update libssl dependency for kernbench

### DIFF
--- a/distro/adaptation/ubuntu-22.04
+++ b/distro/adaptation/ubuntu-22.04
@@ -11,3 +11,4 @@ libx32gcc-dev: libx32gcc-12-dev
 libipsec-mb: libipsec-mb1
 libpython3: libpython3.10
 libtirpc: libtirpc-common
+libssl1.1: libssl3


### PR DESCRIPTION
Currently kernbench install fails on ubuntu
22.04.x:
 E: Unable to locate package libssl1.1
 E: Couldn't find any package by glob 'libssl1.1'
 E: Couldn't find any package by regex 'libssl1.1'
This commit updates the dependency for Ubuntu jammy