### PR TITLE
distro/adaptation: fix libunwind package dependencies mapping of ubuntu

### DIFF
--- a/distro/adaptation/ubuntu-20.04
+++ b/distro/adaptation/ubuntu-20.04
@@ -13,3 +13,4 @@ libx32gcc1: libx32gcc-s1
 lib32gcc-dev: lib32gcc-10-dev
 libx32gcc-dev: libx32gcc-10-dev
 libpython3: libpython3.9
+libunwind: libunwind8


### PR DESCRIPTION
libunwind: install the remaining dependencies for the job, no packages available.
fix for the following error:
$ lkp install -f stream-10000000-10x-100-100%.yaml
......
Use: /opt/lkp-tests/distro/installer/ubuntu install binutils-dev bison build-essential clang default-jdk flex iproute2 libaudit-dev libbabeltrace-dev libcap-dev libclang-dev libdw1 libdw-dev libgtk2.0-dev libiberty-dev liblzma-dev libmpfr6 libnuma-dev libperl-dev libpfm4 libpfm4-dev libpython2.7 libpython3.8 libslang2-dev libssl-dev libunwind libunwind-dev libzstd-dev linux-tools-common llvm-dev numactl patch python3 python3-dev python3-setuptools rng-tools5 sudo systemtap-sdt-dev xz-utils zlib1g-dev binutils-dev bison flex libaudit-dev libbabeltrace-dev libcap-dev libdw-dev libgtk2.0-dev libiberty-dev liblzma-dev libnuma-dev libperl-dev libslang2-dev libunwind-dev libzstd-dev python python3-dev python3-setuptools systemtap-sdt-dev zlib1g-dev
......
Hit:11 http://archive.ubuntu.com/ubuntu focal InRelease
Hit:12 http://archive.ubuntu.com/ubuntu focal-updates InRelease
Hit:13 http://archive.ubuntu.com/ubuntu focal-backports InRelease
Fetched 15.8 kB in 2s (9,852 B/s)
Reading package lists... Done
Reading package lists... Done
Building dependency tree
Reading state information... Done
Note, selecting 'python-is-python2' instead of 'python'
E: Unable to locate package libunwind
Cannot install some packages of perf-c2c depends

Signed-off-by: Yue Zhao <findns94@gmail.com>