### PR TITLE
setup/fs: fix ext4 lazyinit performance issue

### DIFF
--- a/setup/fs
+++ b/setup/fs
@@ -31,8 +31,11 @@ fs_options() {
 		# mkfs.xfs v5.10.0 would set reflink=1 by default, and conflict with DAX mount option, so need to set reflink=0 explicitly
 		ensure_mkfs='-f -mreflink=0'
 		;;
-	ext*)
+	ext2)
 		ensure_mkfs='-q -F'
+		;;
+	ext4)
+		ensure_mkfs='-q -E lazy_itable_init=0,lazy_journal_init=0 -F'
 		;;
 	btrfs)
 		;;


### PR DESCRIPTION
During ext4 filesystem performance test, we find newly formatted ext4 fs will create a lazyinit kernel thread in background, which will disturb fio performance test.
According to https://www.thomas-krenn.com/en/wiki/Ext4_Filesystem#Lazy_Initialization, it is better to disable lazyinit mechanism to make ext4 performance test result similar to workload in realworld.
For ext2, there is no lazyinit mechanism, so the format parameters for ext2 remain as before.

Signed-off-by: Yue Zhao <findns94@gmail.com>