### PR TITLE
distro/adaptation: add mapping for 24.04

### DIFF
--- a/distro/adaptation/ubuntu-24.04
+++ b/distro/adaptation/ubuntu-24.04
@@ -1,0 +1,36 @@
+# noble
+crda:
+cython:
+dh-systemd: debhelper
+exfat-utils: exfatprogs
+fuse: fuse3
+lib32gcc-dev: lib32gcc-12-dev
+libevent-2.1-6: libevent-2.1-7
+libgsl: libgsl27
+libhwloc5: libhwloc15
+libipsec-mb: libipsec-mb1
+libjson: libjson-c5
+libldap-2.4-2: libldap-2.5-0
+libntfs: libntfs-3g89
+libperl5: libperl5.34
+libpolly-dev:
+libprocps: libprocps8
+libpython2.7:
+libpython3: libpython3.10
+libreadline5: readline-common
+libssl: libssl3
+libtirpc: libtirpc-common
+libunwind: libunwind-15
+liburing: liburing2
+libx32gcc-dev: libx32gcc-12-dev
+libx32gcc1: libx32gcc-s1
+mariadb-server:mariadb-server-10.6
+mcelog: rasdaemon
+openjdk: openjdk-17-jdk
+perl-modules-5: perl-modules-5.34
+python3-crypto: python3-pycryptodome
+python3-gobject:
+python3-tox: tox
+python: python-is-python3
+qt5-default: qtbase5-dev
+winpdb:


### PR DESCRIPTION
Some packages like libpython2.7 are missing on Ubuntu Noble.
Create a new mapping to fix this issue.

Signed-off-by: Po-Hsu Lin <po-hsu.lin@canonical.com>
