### PR TITLE
distro/installer/ubuntu: avoid entering interactive mode

### DIFF
--- a/distro/installer/ubuntu
+++ b/distro/installer/ubuntu
@@ -5,7 +5,7 @@ arch=$(get_system_arch)
 
 # enable i386 arch packages
 [ "$arch" = "x86_64" ] && dpkg --add-architecture i386 && apt-get update
-apt-get -o Dpkg::Options::="--force-confdef" \
+yes "" | DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" \
      -o Dpkg::Options::="--force-confold" \
      -o Dpkg::Options::="--force-overwrite" \
      -y install $*


### PR DESCRIPTION
When trying to install the iperf3 package on Ubuntu Noble, it will
drop into an interactive mode asking if we should start iper3 as a
daemon automatically.
    
Avoid this by using the following command for apt command on Ubuntu:
  yes "" | DEBIAN_FRONTEND=noninteractive
