### PR TITLE
replace libdw1 to libdw1t64 on ubuntu-24.04

### DIFF
--- a/distro/adaptation/ubuntu-24.04
+++ b/distro/adaptation/ubuntu-24.04
@@ -34,3 +34,4 @@ python3-tox: tox
 python: python-is-python3
 qt5-default: qtbase5-dev
 winpdb:
+libdw1: libdw1t64


### PR DESCRIPTION
This PR can resolve this issue: my OS version is Ubuntu 24.04, when I install lkp cases failed, error message is:
 "The following packages have unmet dependencies:
 libdw1 : Depends: libelf1 (= 0.176-1.1ubuntu0.1)
 libdw1t64 : Breaks: libdw1 (< 0.190-1.1build4)
E: Unable to correct problems, you have held broken packages.
Cannot install some packages of perf-c2c depends ", please review, thanks.
