### PR TITLE
repo/linux/chrome-os: Drop groeck@ from direct e-mails

### DIFF
--- a/repo/linux/chrome-os
+++ b/repo/linux/chrome-os
@@ -8,7 +8,6 @@ customconfig: customconfig
 notify_build_success_branch: .*
 mail_to:
 - cros-kernel-buildreports@googlegroups.com
-- Guenter Roeck <groeck@google.com>
 too_old_relative_commit_date: month|year|^[4-9]+ weeks
 test_old_branches: .*
 no_merge_branch: .*


### PR DESCRIPTION
I can pick up build reports from the mailing list, so drop the direct e-mails.