### PR TITLE
setup/fio-setup-basic: fix incorrect raw disk capacity calculation

### DIFF
--- a/setup/fio-setup-basic
+++ b/setup/fio-setup-basic
@@ -68,10 +68,18 @@ fi
 [ -z "$storages" ] && die "storages is empty, we can't get jobs_per_storage and nr_task_remain"
 for storage in $storages
 do
-	mnt_point=$(stat -c %m $(readlink -f $storage))
-	available_storage_size=$(df -k | awk '{print $4" "$NF}' | grep $mnt_point$ | awk '{print $1}')
-	[ -n "$available_storage_size" ] || die "storage $storage doesn't mounted"
-	available_storage_size=$(to_byte ${available_storage_size}k)
+	if [ "$raw_disk" = 1 ]; then
+		# for raw disk, using lsblk to get disk capacity in bytes instead of reading filesystem stats
+		# because raw disk will not mount filesystem
+		available_storage_size=$(lsblk -b | grep $(basename $storage) | awk '{print $4}')
+		[ -n "$available_storage_size" ] || die "device $storage doesn't exist"
+	else
+		mnt_point=$(stat -c %m $(readlink -f $storage))
+		available_storage_size=$(df -k | awk '{print $4" "$NF}' | grep $mnt_point$ | awk '{print $1}')
+		[ -n "$available_storage_size" ] || die "storage $storage doesn't mounted"
+		available_storage_size=$(to_byte ${available_storage_size}k)
+	fi
+
 
 	require_size=$test_size
 	df | grep $mnt_point$ | awk '{print $1}' | grep -q /dev/pmem && require_size=$size


### PR DESCRIPTION
This commit can fix when /dev is not shown in `df` command in ubuntu 24.04.
When doing fio with raw disk, we should use `lsblk` to get disk capacity in bytes
instead of reading filesystem stats because raw disk will not mount filesystem

Fix for the following error:
"storage /dev/disk doesn't mounted" when doing fio with raw disk