### PR TITLE
repo/linux: update test repo to forever-address

### DIFF
--- a/repo/linux/gmprice
+++ b/repo/linux/gmprice
@@ -1,5 +1,0 @@
-url: https://github.com/gmprice/linux
-owner: Gregory Price <gregory.price@memverge.com>
-mail_to: Gregory Price <gregory.price@memverge.com>
-mail_cc: Gregory Price <gourry.memverge@gmail.com>
-notify_build_success_branch: .*

--- a/repo/linux/gourryinverse
+++ b/repo/linux/gourryinverse
@@ -1,0 +1,5 @@
+url: https://github.com/gourryinverse/linux
+owner: Gregory Price <gourry@gourry.net>
+mail_to: Gregory Price <gourry@gourry.net>
+mail_cc: Gregory Price <gourry@gourry.net>
+notify_build_success_branch: .*


### PR DESCRIPTION
Disassociating linux identify from company address, moving to forever-address.