### PR TITLE
Fix lkp picking up system's perf and Add new param

### DIFF
--- a/programs/perf-bench-numa-mem/meta.yaml
+++ b/programs/perf-bench-numa-mem/meta.yaml
@@ -8,6 +8,7 @@ parameters:
  nr_processes:
  nr_threads:
  mem_proc:
+ thp_opt:
  extra_params:
 
 results:

--- a/programs/perf-bench-numa-mem/run
+++ b/programs/perf-bench-numa-mem/run
@@ -2,6 +2,7 @@
 # - nr_processes
 # - nr_threads
 # - mem_proc
+# - thp_opt
 # - extra_params
 
 ## perf began as a tool for using the performance counters
@@ -11,6 +12,9 @@
 . $LKP_SRC/lib/unit.sh
 . $LKP_SRC/lib/reproduce-log.sh
 . $LKP_SRC/lib/debug.sh
+. $LKP_SRC/lib/env.sh
+
+set_perf_path "/lkp/benchmarks/perf/perf"
 
 [ -n "$nr_processes" ] || nr_processes=$nr_cpu
 
@@ -18,4 +22,4 @@ mb_proc=$(to_mb $mem_proc)
 
 log_cmd numactl --hard || die "Test needs available numa"
 
-log_cmd perf bench numa mem -p $nr_processes -t $nr_threads -m -0 -P $mb_proc $extra_params
+log_cmd  $perf bench numa mem -p $nr_processes -t $nr_threads -m -0 -P $mb_proc --thp $thp_opt $extra_params


### PR DESCRIPTION
1) Fix: lkp unable to pick latest perf rather using system's perf as a
   consequence unable to run benchmarks on custom kernels
2) Feat: add new parameter # -thp_opt to enable lkp run two different
   variant of the microbenchmark (thp/no_thp) and lkp ncompare able to
   differentiate the results of the same

Reviewed-by: Srikanth Aithal <sraithal@amd.com>