### PR TITLE
Update rt-tests

### DIFF
--- a/programs/hackbench/pkg/PKGBUILD
+++ b/programs/hackbench/pkg/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=hackbench
-pkgver=2.7
+pkgver=2.8
 pkgrel=0
 arch=('i386' 'x86_64' 'riscv64' 'aarch64')
 url="https://www.kernel.org/pub/linux/utils/rt-tests"

--- a/programs/rt-tests/pkg/PKGBUILD
+++ b/programs/rt-tests/pkg/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=rt-tests
-pkgver=2.6
+pkgver=2.8
 pkgrel=0
 pkgdesc="Suite of real-time tests - cyclictest, hwlatdetect, pip_stress, pi_stress, pmqtest, ptsematest, rt-migrate-test, sendme, signaltest, sigwaittest, svsematest"
 arch=('i386' 'x86_64' 'aarch64')


### PR DESCRIPTION
Update rt-tests to avoid install failures.

Before fix:
```
  -> Source is https://www.kernel.org/pub/linux/utils/rt-tests/rt-tests-2.7.tar.gz
  -> Downloading rt-tests-2.7.tar.gz...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0  1946    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404
==> ERROR: Failure while downloading rt-tests-2.7.tar.gz
    Aborting...
Install hackbench failed
```

After fix:

```
  -> Source is https://www.kernel.org/pub/linux/utils/rt-tests/rt-tests-2.8.tar.gz
  -> Downloading rt-tests-2.8.tar.gz...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  152k  100  152k    0     0   118k      0  0:00:01  0:00:01 --:--:--  118k
==> WARNING: Skipping verification of source file PGP signatures.
==> Validating source files with sha256sums...
    rt-tests-2.8.tar.gz ... Skipped
==> Extracting sources...
  -> Source is https://www.kernel.org/pub/linux/utils/rt-tests/rt-tests-2.8.tar.gz
  -> Extracting rt-tests-2.8.tar.gz with bsdtar
==> Starting patch_source()...
..
Setting up hackbench-lkp (2024-12-11) ...
install succeed
```