### PR TITLE
Fix perf package dependencies on redhat

### DIFF
--- a/distro/adaptation/centos
+++ b/distro/adaptation/centos
@@ -15,7 +15,6 @@ clang-6.0: clang.x86_64
 cmake: cmake cmake3
 comerr-dev: libcom_err-devel
 cron: cronie
-curl: curl-minimal
 dbench=4.0-2: dbench
 dc: bc
 default-jdk: java-1.8.0-openjdk-devel 
@@ -65,7 +64,7 @@ libapache2-mpm-itk:
 libapparmor-dev:
 libapparmor1:
 libarchive-dev: libarchive-devel
-libarchive-tools: libarchive
+libarchive-tools: libarchive bsdtar
 libarchive-zip-perl:
 libarchive13: libarchive
 libasound2-dev: alsa-lib-devel
@@ -430,3 +429,4 @@ xutils-dev: imake
 xz-utils: xz
 zlib1g-dev: zlib-devel
 zlib1g: zlib
+libcapstone-dev: capstone-devel


### PR DESCRIPTION
Currently perf install fails citing few dependency failures on redhat 9.4. This commit fixes it.

Before fix:

```
Error: Unable to find a match: curl-minimal
Cannot install some packages of makepkg depends
..
Error: Unable to find a match: libcapstone-dev
Cannot install some packages of perf depends
..

  -> Stripping unneeded symbols from binaries and libraries...
==> Creating package "perf"...
  -> Generating .MTREE file...
/home/LKP/lkp-tests/sbin/makepkg: line 2337: bsdtar: command not found
  -> Compressing package...
/home/LKP/lkp-tests/sbin/makepkg: line 2348: bsdtar: command not found
==> ERROR: Failed to create package file.
Install perf failed
```

After fix:

```
  LINK    perf
  GEN     python/perf.cpython-39-x86_64-linux-gnu.so
==> Entering fakeroot environment...
x86_64
==> Starting package()...
==> Tidying install...
  -> Purging unwanted files...
  -> Removing libtool files...
  -> Removing static library files...
  -> Compressing man and info pages...
  -> Stripping unneeded symbols from binaries and libraries...
==> Creating package "perf"...
  -> Generating .MTREE file...
  -> Compressing package...
==> Leaving fakeroot environment.
==> Finished making: perf git-1 (Wed Dec 11 06:24:54 PM IST 2024)
==> Installing package perf with /home/LKP/lkp-tests/sbin/pacman-LKP -U...
install succeed
```
