### PR TITLE
Fix cannot find arc-elf cross tool

### DIFF
--- a/kbuild/kbuild.sh
+++ b/kbuild/kbuild.sh
@@ -317,9 +317,9 @@ setup_cross_vars()
 			# for earlier gcc version, will failed to find arceb-elf for
 			# big endian arceb-elf tool chain
 			if is_config_enabled CONFIG_CPU_BIG_ENDIAN; then
-				crosstool=arceb-elf
+				crosstool=arceb-linux
 			else
-				crosstool=arc-elf
+				crosstool=arc-linux
 			fi
 			;;
 		c6x)

--- a/kbuild/make.cross
+++ b/kbuild/make.cross
@@ -190,8 +190,9 @@ install_crosstool_gcc()
 	if [[ $gcc_version ]]; then
 		# for arch has more than 1 cross tool available, like x86_64-gcc-9.3.0-nolibc_arm-linux-gnueabi.tar.xz
 		# and x86_64-gcc-9.3.0-nolibc_arm-linux-gnueabihf.tar.xz for arm, match "arm-linux-gnueabi." instead of
-		# "arm-linux-gnueabi" to get single tool package which match exactly.
-		file=$(grep "${gcc_arch_pattern}\..*tar\.xz$" $list | grep "${gcc_version}" | tail -1)
+		# "arm-linux-gnueabi" to get single tool package which match exactly. Also, avoid wrong matching of cross
+		# tool for an other architecture like arc-linux.tar.xz and sparc-linux.tar.xz
+		file=$(grep "\-${gcc_arch_pattern}\.tar\.xz$" $list | grep "${gcc_version}" | tail -1)
 	else
 		file=$(grep "${gcc_arch_pattern}\..*tar\.xz$" $list | tail -1)
 	fi


### PR DESCRIPTION
kbuild/kbuild.sh: change arc cross tool name to arc-linux. This name is valid for all gcc versions

Error: Cannot find arc-elf under https://cdn.kernel.org/pub/tools/crosstool/files/bin/x86_64/

kbuild/make.cross: change cross tool matching pattern. Avoid sparc-linux being used instead of arc-linux

Error: lftpget -c https://cdn.kernel.org/pub/tools/crosstool/files/bin/x86_64/./14.2.0/x86_64-gcc-14.2.0-nolibc-sparc-linux.tar.xz