### PR TITLE
Update local unixbench patch

### DIFF
--- a/programs/unixbench/pkg/unixbench.patch
+++ b/programs/unixbench/pkg/unixbench.patch
@@ -1,5 +1,5 @@
 diff --git a/UnixBench/Makefile b/UnixBench/Makefile
-index 4874d1f43a11..624000a2d15a 100644
+index 50d8139..4184a57 100644
 --- a/UnixBench/Makefile
 +++ b/UnixBench/Makefile
 @@ -46,7 +46,7 @@ SHELL = /bin/sh
@@ -8,13 +8,13 @@ index 4874d1f43a11..624000a2d15a 100644
  # Comment the line out to disable these tests.
 -# GRAPHIC_TESTS = defined
 +GRAPHIC_TESTS = defined
-
+ 
  # Set "GL_LIBS" to the libraries needed to link a GL program.
  GL_LIBS = -lGL -lXext -lX11
 @@ -90,18 +90,18 @@ else
    ## OS detection.  Comment out if gmake syntax not supported by other 'make'. 
    OSNAME:=$(shell uname -s)
-   ARCH := $(shell uname -m)
+   ARCH ?= $(shell uname -m)
 -  ifeq ($(OSNAME),Linux)
 -    # Not all CPU architectures support "-march" or "-march=native".
 -    #   - Supported    : x86, x86_64, ARM, AARCH64, riscv64, etc..
@@ -43,24 +43,24 @@ index 4874d1f43a11..624000a2d15a 100644
    ifeq ($(OSNAME),Darwin)
      # (adjust flags or comment out this section for older versions of XCode or OS X)
 diff --git a/UnixBench/Run b/UnixBench/Run
-index 34d2c72..205fd01 100755
+index 4151248..123cbd3 100755
 --- a/UnixBench/Run
 +++ b/UnixBench/Run
 @@ -999,7 +999,7 @@ sub getSystemInfo {
      }
-
+ 
      # Get graphics hardware info.
 -    $info->{'graphics'} = getCmdOutput("3dinfo | cut -f1 -d\'(\'");
 +    #$info->{'graphics'} = getCmdOutput("3dinfo | cut -f1 -d\'(\'");
-
+ 
      # Get system run state, load and usage info.
      $info->{'runlevel'} = getCmdOutput("who -r | awk '{print \$3}'");
 @@ -2066,7 +2066,7 @@ sub main {
      my @creatingDirectories = ( ${TMPDIR}, ${RESULTDIR} );
      createDirrectoriesIfNotExists(@creatingDirectories);
-
+ 
 -    preChecks();
 +    #preChecks();
      my $systemInfo = getSystemInfo($verbose);
-
+ 
      # If the number of copies to run was not set, set it to 1


### PR DESCRIPTION
Due to upstream unixbench changes, local unixbench patch apply was failing. This commit rebases the
local unixbench patch to recent upstream version.


Unixbench install Issue on latest lkp-tests:
```
==> Starting patch_source()...
patching file UnixBench/Makefile
Hunk #2 FAILED at 90.
1 out of 2 hunks FAILED -- saving rejects to file UnixBench/Makefile.rej
patching file UnixBench/Run
==> ERROR: A failure occurred in patch_source().
    Aborting...
Install unixbench failed
```
After this patch:
```
==> Starting patch_source()...
patching file UnixBench/Makefile
patching file UnixBench/Run
==> Starting build()...
make distr
make[1]: Entering directory '/home/LKP/lkp-tests/tmp-pkg/unixbench/src/byte-unixbench/UnixBench'
Checking distribution of files
./pgms  exists
./src  exists
./testdir  exists
make[1]: Leaving directory '/home/LKP/lkp-tests/tmp-pkg/unixbench/src/byte-unixbench/UnixBench'
make programs
make[1]: Entering directory '/home/LKP/lkp-tests/tmp-pkg/unixbench/src/byte-unixbench/UnixBench'
cc -o pgms/arithoh -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector-strong --param=ssp-buffer-size=4 -Wall -pedantic -O3 -ffast-math -I ./src 
..
..
Setting up unixbench-lkp (2025-02-12) ...
install succeed
```