### PR TITLE
Fix rt-tests md5sum

### DIFF
--- a/programs/rt-tests/pkg/PKGBUILD
+++ b/programs/rt-tests/pkg/PKGBUILD
@@ -6,7 +6,7 @@ arch=('i386' 'x86_64' 'aarch64')
 url="https://git.kernel.org/cgit/utils/rt-tests/rt-tests.git/"
 license=('GPL')
 source=("https://www.kernel.org/pub/linux/utils/rt-tests/rt-tests-$pkgver.tar.gz")
-md5sums=('1034236660c2be3f8b6b1a9cdfd3bc7f')
+md5sums=('4548521cc25e6d01f636dcd460bb0019')
 
 build() {
         cd "$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
Fix rt-tests package md5sum.

Before fix:
```
==> Checking buildtime dependencies...
==> Retrieving sources...
  -> Source is https://www.kernel.org/pub/linux/utils/rt-tests/rt-tests-2.8.tar.gz
  -> Found rt-tests-2.8.tar.gz
==> WARNING: Skipping verification of source file PGP signatures.
==> Validating source files with md5sums...
    rt-tests-2.8.tar.gz ... FAILED
==> ERROR: One or more files did not pass the validity check!
Install rt-tests failed
```

After fix:
```
  -> Source is https://www.kernel.org/pub/linux/utils/rt-tests/rt-tests-2.8.tar.gz
  -> Extracting rt-tests-2.8.tar.gz with bsdtar
==> Starting patch_source()...
PWD=/home/lkp-tests/tmp-pkg/hackbench/src, startdir=/home/lkp-tests/programs/hackbench/pkg, pkgname=hackbench, srcdir=/home/lkp-tests/tmp-pkg/hackbench/src
==> Entering fakeroot environment...
x86_64
==> Starting package()...
..
==> Installing package hackbench with /home/lkp-tests/sbin/pacman-LKP -U...
install succeed
```