### PR TITLE
Fix fedora/41 'No match for argument: libpcre3-dev'

### DIFF
--- a/distro/adaptation/fedora-41
+++ b/distro/adaptation/fedora-41
@@ -11,6 +11,7 @@ liblzo2-dev: lzo-devel
 libncurses5: ncurses
 libnfs13: libnfs
 librbd-dev: librbd-devel
+libpcre3-dev: pcre-devel
 libsasl2-dev: cyrus-sasl-devel
 libsdl2-2.0-0: SDL2
 libseccomp2: libseccomp


### PR DESCRIPTION
Closes #470