### PR TITLE
Add for-kernelci branch to branch_denylist for official PCI tree

### DIFF
--- a/repo/linux/pci
+++ b/repo/linux/pci
@@ -16,3 +16,4 @@ subsystems:
 - pcie
 - aer
 notify_build_success_branch: .*
+branch_denylist: for-kernelci


### PR DESCRIPTION
Add the `for-kernelci` branch to `branch_denylist` property for the official PCI tree.

There is no need for the Intel 0-day Bot to run builds and tests against this specific branch.