### PR TITLE
kernel-selftests.sh: trigger top-level selftests Makefile when building

### DIFF
--- a/lib/tests/kernel-selftests.sh
+++ b/lib/tests/kernel-selftests.sh
@@ -702,11 +702,7 @@ run_tests()
 		[[ $exit_status = 2 ]] && return $exit_status
 		[[ $exit_status = 0 ]] || die "fixup_$group failed as $exit_status"
 
-		if grep -E -q -m 1 "^TARGETS \+?=  ?$group" Makefile; then
-			log_cmd make -j${nr_cpu} -C $group 2>&1
-		else
-			log_cmd make -j${nr_cpu} TARGETS=$group 2>&1
-		fi
+		log_cmd make -j${nr_cpu} TARGETS=$group 2>&1
 
 		# vmalloc performance and stress, can not use 'make run_tests' to run
 		if [[ $test =~ ^vmalloc\-(performance|stress)$ ]]; then


### PR DESCRIPTION
Some logic in top-level Makefile in selftests can be missed when we only run sub-level Makefile (e.g. net selftests have the logic to automatically include net/lib in top-level Makefile in selftests). So this commit removes the logic to selectively run sub-level Makefile only and always runs top-level Makefile with the correct TARGETS.

Link: https://lore.kernel.org/oe-lkp/202505281004.6c3d0188-lkp@intel.com/