### PR TITLE
repo/linux/modules: extend tree info

### DIFF
--- a/repo/linux/modules
+++ b/repo/linux/modules
@@ -1,1 +1,15 @@
 url: https://git.kernel.org/pub/scm/linux/kernel/git/modules/linux.git
+owner:
+- Luis Chamberlain <mcgrof@kernel.org>
+- Petr Pavlu <petr.pavlu@suse.com>
+- Sami Tolvanen <samitolvanen@google.com>
+- Daniel Gomez <da.gomez@kernel.org>
+subsystems:
+- modules
+mail_cc:
+- Luis Chamberlain <mcgrof@kernel.org>
+- Petr Pavlu <petr.pavlu@suse.com>
+- Sami Tolvanen <samitolvanen@google.com>
+- Daniel Gomez <da.gomez@kernel.org>
+- linux-modules@vger.kernel.org
+notify_build_success_branch: .*


### PR DESCRIPTION
Add owner, subsystems and mail_cc information for linux-modules.

Reports are cc to the modules maintainers and reviewers as well as to the mailing list.

Enable reports for build success or regression.