### PR TITLE
Enhance sysinfo.sh to include nr_cores in LLC domain

### DIFF
--- a/distro/adaptation/centos/9
+++ b/distro/adaptation/centos/9
@@ -42,6 +42,7 @@ python3-hid: python3-hidapi
 python3-mako: python-pyramid-mako
 python3-markupsafe: python34-markupsafe
 python3-minimal: python3
+python-minimal: python3
 python3-nose:
 python3-openssl: python3-pyOpenSSL
 python3-pkg-resources:

--- a/lib/sysinfo.sh
+++ b/lib/sysinfo.sh
@@ -7,7 +7,13 @@ setup_threads_to_iterate()
 
 	local threads_per_core
 	local cores_per_node
+	local cores_per_llc
+	local nr_l3
+	local nr_l2
 	threads_per_core=$(lscpu | awk '/Thread\(s\) per core:/ { print $4 }')
+	nr_l3=$(lscpu | grep 'L3' | awk -F '[()]' '{print $2}' | awk '{print $1}')
+	nr_l2=$(lscpu | grep 'L2' | awk -F '[()]' '{print $2}' | awk '{print $1}')
+	cores_per_llc=$((nr_l2 / nr_l3))
 	cores_per_node=$((nr_cpu / nr_node / threads_per_core))
 
 	# [    0.000000] Intel MultiProcessor Specification v1.4
@@ -24,7 +30,7 @@ setup_threads_to_iterate()
 	local i
 	for i in $(seq $nr_node)
 	do
-		threads_to_iterate="${threads_to_iterate} $((i * cores_per_node))"
+		threads_to_iterate="${threads_to_iterate} ${cores_per_llc} $((i * cores_per_node))"
 	done
 
 	[ "$nr_cpu" -ge 4 ] && {


### PR DESCRIPTION
Implement logic to calculate number of cores in LLC domain and use it to populate threads_to_iterate array.
Fix: will-it-scale installation issues on RHEL systems. Updating the python version in distro/adaptation seems to work good.