### PR TITLE
Fix: rt-tests package version

### DIFF
--- a/programs/hackbench/pkg/PKGBUILD
+++ b/programs/hackbench/pkg/PKGBUILD
@@ -1,5 +1,5 @@
 pkgname=hackbench
-pkgver=2.8
+pkgver=2.9
 pkgrel=0
 arch=('i386' 'x86_64' 'riscv64' 'aarch64')
 url="https://www.kernel.org/pub/linux/utils/rt-tests"

--- a/programs/rt-tests/pkg/PKGBUILD
+++ b/programs/rt-tests/pkg/PKGBUILD
@@ -1,12 +1,12 @@
 pkgname=rt-tests
-pkgver=2.8
+pkgver=2.9
 pkgrel=0
 pkgdesc="Suite of real-time tests - cyclictest, hwlatdetect, pip_stress, pi_stress, pmqtest, ptsematest, rt-migrate-test, sendme, signaltest, sigwaittest, svsematest"
 arch=('i386' 'x86_64' 'aarch64')
 url="https://git.kernel.org/cgit/utils/rt-tests/rt-tests.git/"
 license=('GPL')
 source=("https://www.kernel.org/pub/linux/utils/rt-tests/rt-tests-$pkgver.tar.gz")
-md5sums=('4548521cc25e6d01f636dcd460bb0019')
+md5sums=('6508738724960b2e63f21012c2682281')
 
 build() {
         cd "$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
rt-tests package version has been updated from 2.8 -> 2.9 as its latest version in its source
"https://www.kernel.org/pub/linux/utils/rt-tests/". Hence updating the same in $pkgver of the build script for hackbench and rt-tests.

Signed-off-by: Suneeth D <Suneeth.D@amd.com>
Reviewed-by: Srikanth Aithal <sraithal@amd.com>