### PR TITLE
Fix Git URL parsing in get_protocol

### DIFF
--- a/sbin/makepkg
+++ b/sbin/makepkg
@@ -274,7 +274,7 @@ get_url() {
 
 # extract the protocol from a source entry - return "local" for local sources
 get_protocol() {
-	if [[ $1 =~ \.git ]]; then
+	if [[ $1 =~ \.git$ ]]; then
 		printf "%s\n" "git"
 	elif [[ $1 = *://* ]]; then
 		# strip leading filename


### PR DESCRIPTION
The get_protocol function incorrectly identified URLs containing ".git" anywhere in the string as Git repositories, causing errors when downloading raw files. This commit updates the regex to match ".git$" (end of string).