### PR TITLE
repos/linux: add glemco

### DIFF
--- a/repo/linux/glemco
+++ b/repo/linux/glemco
@@ -1,0 +1,6 @@
+url: https://gitlab.com/glemco/linux
+owner: Gabriele Monaco <gmonaco@redhat.com>
+notify_build_success_branch: .*
+private_report_branch: .*
+branch_allowlist: staging_.*
+branch_denylist: .*


### PR DESCRIPTION
Add my tree at https://gitlab.com/glemco/linux
Run tests only on staging_* branches.