### PR TITLE
bin/run-local-monitor.sh: Avoid to include quote in rootfs variable

### DIFF
--- a/bin/run-local-monitor.sh
+++ b/bin/run-local-monitor.sh
@@ -29,7 +29,7 @@ set_local_variables()
 	export arch=$(get_system_arch)
 	export compiler=$(grep -o "gcc version [0-9]*" /proc/version | awk '{print "gcc-"$NF}')
 	export compiler=${compiler:-gcc}
-	export rootfs=$(grep -m1 ^ID= /etc/os-release | awk -F= '{print $2}')
+	export rootfs=$(source /etc/os-release; echo $ID)
 	export rootfs=${rootfs:-default_rootfs}
 
 	export testbox=$HOSTNAME


### PR DESCRIPTION
From

https://www.freedesktop.org/software/systemd/man/latest/os-release.html

the format of /etc/os-release file is shell variable like to support sourced in a shell script.  So, that is the best method to parse the file.

While the original method may include quote in the result variable, for example, for

$ cat /etc/os-release
...
ID="mydist"
...

we will get rootfs="mydist" with the original method, while we will get rootfs=mydist with shell source method.

So, use the shell source method to avoid the issue.