### PR TITLE
install: skip package checking if target benchmark installed

### DIFF
--- a/lkp-exec/install
+++ b/lkp-exec/install
@@ -428,6 +428,12 @@ do
 			script=$(basename "$real_script")
 		}
 
+		benchmark_package=$(get_adaptation_pkg $distro "$script")
+		if verify_install "$benchmark_package" && [ -z "$FORCE_MODE" ]; then
+			echo "package '$benchmark_package' installed."
+			continue
+		fi
+
 		pkg_dir=$(get_pkg_dir $script)
 		[ -z "$makepkg_once" ] && [ -n "$pkg_dir" ] && ! [ -x "$LKP_SRC/pack/$script" ] && {
 			install_packages "makepkg" $distro
@@ -437,7 +443,6 @@ do
 		install_packages "$script" $distro
 		makepkg_install_packages "$script" $distro || exit 1
 
-		benchmark_package=$(get_adaptation_pkg $distro "$script")
 		if [ -n "$FORCE_MODE" ] || ! verify_install "$benchmark_package"; then
 			makepkg_install_benchmark "$script" $distro || exit 1
 		fi


### PR DESCRIPTION
Don't install depends if the target pacakge is installed, unless '-f' set.