### PR TITLE
Fix lmbench build issue

### DIFF
--- a/programs/lmbench3/pkg/Fix-rpc.h-not-found.patch
+++ b/programs/lmbench3/pkg/Fix-rpc.h-not-found.patch
@@ -1,29 +1,15 @@
-From a3423b73ee44631e7bb48f8d5967ca706e66567c Mon Sep 17 00:00:00 2001
-From: Hao Li <lihao2018.fnst@cn.fujitsu.com>
-Date: Mon, 14 Dec 2020 10:48:06 +0800
-Subject: [PATCH] Fix rpc.h not found
+From cf33d3e5473ea300161e7ff03cb468daf86036e1 Mon Sep 17 00:00:00 2001
+From: Suneeth D <Suneeth.D@amd.com>
+Date: Tue, 12 Aug 2025 09:01:31 +0000
+Subject: [PATCH] [PATCH] Fix rpc.h not found
 
-Signed-off-by: Hao Li <lihao2018.fnst@cn.fujitsu.com>
+Signed-off-by: Suneeth D <Suneeth.D@amd.com>
 ---
- scripts/build | 2 +-
- src/Makefile  | 4 ++++
- 2 files changed, 5 insertions(+), 1 deletion(-)
+ src/Makefile | 4 ++++
+ 1 file changed, 4 insertions(+)
 
-diff --git a/scripts/build b/scripts/build
-index 16a6600..561cdb3 100755
---- a/scripts/build
-+++ b/scripts/build
-@@ -18,7 +18,7 @@ done
- 
- trap 'rm -f ${BASE}$$.s ${BASE}$$.c ${BASE}$$.o ${BASE}$$; exit 1' 1 2 15
- 
--LDLIBS=-lm
-+LDLIBS="-lm -ltirpc"
- 
- # check for HP-UX's ANSI compiler
- echo "main(int ac, char *av[]) { int i; }" > ${BASE}$$.c
 diff --git a/src/Makefile b/src/Makefile
-index 2555014..faca887 100644
+index 2555014faba6..faca887e70a8 100644
 --- a/src/Makefile
 +++ b/src/Makefile
 @@ -60,6 +60,10 @@ SAMPLES=lmbench/Results/aix/rs6000 lmbench/Results/hpux/snake \
@@ -38,5 +24,5 @@ index 2555014..faca887 100644
  
  SRCS =  bw_file_rd.c bw_mem.c bw_mmap_rd.c bw_pipe.c bw_tcp.c bw_udp.c	\
 -- 
-2.29.2
+2.43.0
 


### PR DESCRIPTION
lmbench3 build fails while applying one of the hunks from the local patch maintained in lkp. The reason was that the same hunk from the patch has been upstreamed in the source
(https://github.com/intel/lmbench.git) which was conflicting. Hence generated a patch after removal of the conflicting hunk.

Signed-off-by: Suneeth D <Suneeth.D@amd.com>
Reviewed-and-tested-by: Srikanth Aithal <srikanth.aithal@amd.com>