### PR TITLE
Avoid disabling THP when run job

### DIFF
--- a/bin/run-local
+++ b/bin/run-local
@@ -152,7 +152,9 @@ user = ENV['USER']
 save_paths(result_root, user)
 
 system 'killall', '-q', "#{LKP_SRC}/bin/event/wakeup"
-system job_script, 'run_job'
+
+with_thp_enabled { system job_script, 'run_job' }
+
 system "#{LKP_SRC}/bin/run-with-job", job_script, "#{LKP_SRC}/bin/post-run"
 system "#{LKP_SRC}/bin/event/wakeup", 'job-finished'
 


### PR DESCRIPTION
THP is disabled in ruby after version 2.6.  This will disable THP for job run by ruby too.  Enable THP when run job to avoid the issue.