### PR TITLE
repo/linux: Update Will Deacon's e-mail address

### DIFF
--- a/repo/linux/arm-perf
+++ b/repo/linux/arm-perf
@@ -1,6 +1,6 @@
 url: https://git.kernel.org/pub/scm/linux/kernel/git/will/linux.git
 integration_testing_branches: for-next/perf
-owner: Will Deacon <will.deacon@arm.com>
+owner: Will Deacon <will@kernel.org>
 subsystems:
 - arm64
 - iommu

--- a/repo/linux/arm64
+++ b/repo/linux/arm64
@@ -4,7 +4,7 @@ mail_cc:
 - linux-arm-kernel@lists.infradead.org
 owner:
 - Catalin Marinas <catalin.marinas@arm.com>
-- Will Deacon <will.deacon@arm.com>
+- Will Deacon <will@kernel.org>
 subsystems:
 - arm64
 - psci

--- a/repo/linux/penberg-kvm
+++ b/repo/linux/penberg-kvm
@@ -1,5 +1,5 @@
 url: https://github.com/penberg/linux-kvm.git
-owner: Will Deacon <will.deacon@arm.com>
+owner: Will Deacon <will@kernel.org>
 subsystems:
 - kvmtool
 - arm


### PR DESCRIPTION
Will Deacon no longer works for ARM. Update his e-mail address to will@kernel.org.

Suggested-by: Will Deacon <will@kernel.org>