### PR TITLE
distro/adaptation/amazon_linux/default: map tpm-udev to tpm2-tools

### DIFF
--- a/distro/adaptation/amazon_linux/default
+++ b/distro/adaptation/amazon_linux/default
@@ -422,6 +422,7 @@ systemtap-sdt-dev: systemtap-sdt-devel
 telnetd-ssl:
 thin-provisioning-tools:
 tpm-tools: tpm2-tools
+tpm-udev: tpm2-tools
 trinity:
 udftools:
 usbutils:

--- a/distro/adaptation/amazon_linux/default
+++ b/distro/adaptation/amazon_linux/default
@@ -422,7 +422,7 @@ systemtap-sdt-dev: systemtap-sdt-devel
 telnetd-ssl:
 thin-provisioning-tools:
 tpm-tools: tpm2-tools
-tpm-udev: tpm2-tools
+tpm-udev:
 trinity:
 udftools:
 usbutils:

--- a/distro/adaptation/archlinux/default
+++ b/distro/adaptation/archlinux/default
@@ -62,6 +62,7 @@ python-minimal: python2
 qemu-system-x86: qemu
 ruby-gnuplot:
 sg3-utils: sg3_utils
+tpm-udev:
 uuid-dev: uuid
 xfslibs-dev: xfsprogs
 xinit: xorg-xinit

--- a/distro/adaptation/centos/default
+++ b/distro/adaptation/centos/default
@@ -505,6 +505,7 @@ systemtap-sdt-dev: systemtap-sdt-devel
 telnetd-ssl:
 texinfo: texinfo-tex
 thin-provisioning-tools:
+tpm-udev:
 trinity:
 tshark: wireshark
 uidmap: shadow-utils

--- a/distro/adaptation/fedora/default
+++ b/distro/adaptation/fedora/default
@@ -441,6 +441,7 @@ systemd-dev: systemd-devel
 systemtap-sdt-dev: systemtap-sdt-devel
 telnetd-ssl:
 thin-provisioning-tools:
+tpm-udev:
 tshark: wireshark
 uidmap: shadow-utils
 update-inetd:

--- a/distro/adaptation/opensuse/default
+++ b/distro/adaptation/opensuse/default
@@ -381,6 +381,7 @@ stress: stress-ng
 systemd-dev:
 systemtap-sdt-dev: systemtap-sdt-devel
 telnetd-ssl:
+tpm-udev:
 tshark: wireshark
 uidmap: shadow
 update-inetd:


### PR DESCRIPTION
Add mapping for the tpm-udev package to its amazon_linux equivalent, tpm2-tools, to satisfy setup dependencies during test deployment.