### PR TITLE
distro/adaptation: skip tpm-udev on non-Debian distributions

### DIFF
--- a/distro/adaptation/amazon_linux/default
+++ b/distro/adaptation/amazon_linux/default
@@ -422,6 +422,7 @@ systemtap-sdt-dev: systemtap-sdt-devel
 telnetd-ssl:
 thin-provisioning-tools:
 tpm-tools: tpm2-tools
+tpm-udev: tpm2-tools
 trinity:
 udftools:
 usbutils:

--- a/distro/adaptation/archlinux/default
+++ b/distro/adaptation/archlinux/default
@@ -62,6 +62,7 @@ python-minimal: python2
 qemu-system-x86: qemu
 ruby-gnuplot:
 sg3-utils: sg3_utils
+tpm-udev: tpm2-tools
 uuid-dev: uuid
 xfslibs-dev: xfsprogs
 xinit: xorg-xinit

--- a/distro/adaptation/centos/default
+++ b/distro/adaptation/centos/default
@@ -505,6 +505,7 @@ systemtap-sdt-dev: systemtap-sdt-devel
 telnetd-ssl:
 texinfo: texinfo-tex
 thin-provisioning-tools:
+tpm-udev: tpm2-tools
 trinity:
 tshark: wireshark
 uidmap: shadow-utils

--- a/distro/adaptation/fedora/default
+++ b/distro/adaptation/fedora/default
@@ -441,6 +441,7 @@ systemd-dev: systemd-devel
 systemtap-sdt-dev: systemtap-sdt-devel
 telnetd-ssl:
 thin-provisioning-tools:
+tpm-udev: tpm2-tools
 tshark: wireshark
 uidmap: shadow-utils
 update-inetd:

--- a/distro/adaptation/opensuse/default
+++ b/distro/adaptation/opensuse/default
@@ -381,6 +381,7 @@ stress: stress-ng
 systemd-dev:
 systemtap-sdt-dev: systemtap-sdt-devel
 telnetd-ssl:
+tpm-udev: tpm2.0-tools
 tshark: wireshark
 uidmap: shadow
 update-inetd:


### PR DESCRIPTION
Map tpm-udev to an empty string on non-Debian distributions to ensure the package is only strictly requested and installed on Debian. This prevents adaptation scripts from failing when the package manager attempts to find the equivalent package on other distributions.

Other distros incorporate the contents of tpm-udev in tpm-tools, etc