### PR TITLE
repo: update batman-adv tree URL

### DIFF
--- a/repo/linux/batman
+++ b/repo/linux/batman
@@ -1,4 +1,4 @@
-url: https://git.open-mesh.org/linux-merge.git
+url: https://git.open-mesh.org/batadv.git
 owner: Simon Wunderlich <sw@simonwunderlich.de>
 mail_cc: Sven Eckelmann <sven@narfation.org>
 subsystems:


### PR DESCRIPTION
The batman-adv sub-sub-system tree was renamed to have give a hint want prefix ("batadv") should be added to patches targetting the batman-adv tree.

The old URL is redirected at the moment to the new path. But it is unclear how long this will be the case.