### PR TITLE
programs: add no-op build() to non-compiling PKGBUILDs

### DIFF
--- a/programs/autonuma-benchmark/pkg/PKGBUILD
+++ b/programs/autonuma-benchmark/pkg/PKGBUILD
@@ -9,3 +9,9 @@ sha256sums=('SKIP')
 
 . $LKP_SRC/lib/tests/pkgbuild.sh
 
+# No compile step; override the default build() (make_src_pkg from pkgbuild.sh)
+# so install doesn't run make on the unbuilt source.
+build()
+{
+	:
+}

--- a/programs/bpftrace/pkg/PKGBUILD
+++ b/programs/bpftrace/pkg/PKGBUILD
@@ -11,6 +11,13 @@ md5sums=('SKIP')
 
 . $LKP_SRC/lib/tests/pkgbuild.sh
 
+# No compile step; override the default build() (make_src_pkg from pkgbuild.sh)
+# so install doesn't run make on the unbuilt source.
+build()
+{
+	:
+}
+
 package()
 {
     mkdir -p $benchmark_path

--- a/programs/cassandra/pkg/PKGBUILD
+++ b/programs/cassandra/pkg/PKGBUILD
@@ -12,6 +12,13 @@ md5sums=('SKIP')
 . $LKP_SRC/lib/reproduce-log.sh
 . $LKP_SRC/lib/tests/pkgbuild.sh
 
+# No compile step; override the default build() (make_src_pkg from pkgbuild.sh)
+# so install doesn't run make on the unbuilt source.
+build()
+{
+	:
+}
+
 prepare()
 {
 	prepare_benchmark_path

--- a/programs/chromeswap/pkg/PKGBUILD
+++ b/programs/chromeswap/pkg/PKGBUILD
@@ -9,3 +9,9 @@ md5sums=('SKIP')
 
 . $LKP_SRC/lib/tests/pkgbuild.sh
 
+# No compile step; override the default build() (make_src_pkg from pkgbuild.sh)
+# so install doesn't run make on the unbuilt source.
+build()
+{
+	:
+}

--- a/programs/kernbench/pkg/PKGBUILD
+++ b/programs/kernbench/pkg/PKGBUILD
@@ -11,6 +11,14 @@ md5sums=('SKIP' 'SKIP')
 
 . $LKP_SRC/lib/tests/pkgbuild.sh
 
+# kernbench has nothing to compile (the kernbench source is a single script and
+# the linux tarball is only packed), so override the default build() which would
+# otherwise run make_src_pkg and try to 'cd' into the non-directory src/kernbench.
+build()
+{
+	:
+}
+
 package()
 {
 	pack_contents "$srcdir/linux-${kernel_ver}/" "$benchmark_path/linux"

--- a/programs/ku-latency/pkg/PKGBUILD
+++ b/programs/ku-latency/pkg/PKGBUILD
@@ -12,6 +12,13 @@ md5sums=('SKIP' 'SKIP' 'SKIP')
 . $LKP_SRC/lib/install.sh
 . $LKP_SRC/lib/tests/pkgbuild.sh
 
+# Compilation happens in package() via gcc; override the default build()
+# (make_src_pkg from pkgbuild.sh) so install doesn't run make on the unbuilt source.
+build()
+{
+	:
+}
+
 patch_source()
 {
 	# PWD=/tmp/lkp/ku-latency/src, srcdir=/tmp/lkp/ku-latency/src

--- a/programs/leaking-addresses/pkg/PKGBUILD
+++ b/programs/leaking-addresses/pkg/PKGBUILD
@@ -9,6 +9,13 @@ md5sums=('SKIP')
 
 . $LKP_SRC/lib/tests/pkgbuild.sh
 
+# No compile step; override the default build() (make_src_pkg from pkgbuild.sh)
+# so install doesn't run make on the unbuilt source.
+build()
+{
+	:
+}
+
 pkgver()
 {
 	# get the last commit of leaking_addresses.pl

--- a/programs/libhugetlbfs-test/pkg/PKGBUILD
+++ b/programs/libhugetlbfs-test/pkg/PKGBUILD
@@ -12,6 +12,13 @@ md5sums=('SKIP' 'SKIP')
 . $LKP_SRC/lib/install.sh
 . $LKP_SRC/lib/tests/pkgbuild.sh
 
+# No compile step; override the default build() (make_src_pkg from pkgbuild.sh)
+# so install doesn't run make on the unbuilt source.
+build()
+{
+	:
+}
+
 patch_source()
 {
 	[ "$DISTRO" = "centos" ] || return 0

--- a/programs/nuttcp/pkg/PKGBUILD
+++ b/programs/nuttcp/pkg/PKGBUILD
@@ -10,6 +10,13 @@ md5sums=('SKIP')
 
 . $LKP_SRC/lib/tests/pkgbuild.sh
 
+# Prebuilt binary, no compile step; override the default build() (make_src_pkg
+# from pkgbuild.sh) so install doesn't run make on the unbuilt source.
+build()
+{
+	:
+}
+
 package()
 {
 	cd "${srcdir}"

--- a/programs/pybench/pkg/PKGBUILD
+++ b/programs/pybench/pkg/PKGBUILD
@@ -9,6 +9,13 @@ md5sums=('e3ca0e887e4310896d32dd1cbd258a94')
 
 . $LKP_SRC/lib/tests/pkgbuild.sh
 
+# No compile step; override the default build() (make_src_pkg from pkgbuild.sh)
+# so install doesn't run make on the unbuilt source.
+build()
+{
+	:
+}
+
 prepare()
 {
 	prepare_benchmark_path

--- a/programs/stream/pkg/PKGBUILD
+++ b/programs/stream/pkg/PKGBUILD
@@ -9,6 +9,13 @@ md5sums=('SKIP')
 
 . $LKP_SRC/lib/tests/pkgbuild.sh
 
+# No compile step; override the default build() (make_src_pkg from pkgbuild.sh)
+# so install doesn't run make on the unbuilt source.
+build()
+{
+	:
+}
+
 package()
 {
 	pack_src_pkg_contents stream.c


### PR DESCRIPTION
Commit c87c0b86a6b7 ("programs: refactor PKGBUILD to remove duplicated code") added default prepare(), build() and package() functions to lib/tests/pkgbuild.sh and dropped the now-duplicated definitions from the individual PKGBUILDs.

The default build() runs make_src_pkg, which does:
    cd_src_pkg_dir   # cd $srcdir/$pkgname
    ...
    make -j$(nproc)

This is correct only for packages whose source is a buildable directory named after $pkgname. Several packages, however, never defined build() at all and have nothing to compile (prebuilt binaries, plain scripts, git/tarball sources that are packed as-is, or sources compiled directly in package()). Before the refactor makepkg simply skipped the build step for them; afterwards they wrongly inherit the default build() and fail

Restore the original "no build" behaviour by overriding the inherited default with a no-op build() in the affected packages:
  kernbench, autonuma-benchmark, bpftrace, cassandra, chromeswap,
  ku-latency, leaking-addresses, libhugetlbfs-test, nuttcp, pybench, stream

Fixes: c87c0b86a6b7 ("programs: refactor PKGBUILD to remove duplicated code")

Before this commit:
---------------------
==> Starting build()...
2026-06-11 05:45:59 cd /home/LKP/LKP/lkp-tests/tmp-pkg/stream/src/stream
gcc -O2 -fopenmp -D_FORTIFY_SOURCE=2  -c -o mysecond.o mysecond.c
gcc -O2 -fopenmp stream.c -o stream_c.exe
gcc -O2 -fopenmp -c mysecond.c
gfortran -O2 -fopenmp -c stream.f
make: gfortran: No such file or directory
make: *** [Makefile:11: stream_f.exe] Error 127
make: *** Waiting for unfinished jobs....
==> ERROR: A failure occurred in build().
    Aborting...
Install stream failed

After this commit:
--------------------
==> Starting build()...
==> Entering fakeroot environment...
x86_64
==> Starting package()...
2026-06-11 05:48:05 cp -a stream.c /home/LKP/LKP/lkp-tests/tmp-pkg/stream/pkg/stream/lkp/benchmarks/stream
==> Tidying install...
  -> Purging unwanted files...
  -> Removing libtool files...
  -> Removing static library files...
  -> Compressing man and info pages...
  -> Stripping unneeded symbols from binaries and libraries...
==> Creating package "stream"...
  -> Generating .MTREE file...
  -> Compressing package...
==> Leaving fakeroot environment.
==> Finished making: stream git-1 (Thu Jun 11 05:48:05 AM UTC 2026)
==> Installing package stream with /home/LKP/LKP/lkp-tests/sbin/pacman-LKP -U...
dpkg-deb: building package 'stream-lkp' in 'stream-lkp.deb'.
(Reading database ... 351950 files and directories currently installed.)
Preparing to unpack stream-lkp.deb ...
Unpacking stream-lkp (2026-06-11) over (2026-06-11) ...
Setting up stream-lkp (2026-06-11) ...
install succeed