### PR TITLE
Fix benchmarks incomplete run

### DIFF
--- a/programs/kernbench/pkg/PKGBUILD
+++ b/programs/kernbench/pkg/PKGBUILD
@@ -21,7 +21,7 @@ build()
 
 package()
 {
-	pack_contents "$srcdir/linux-${kernel_ver}/" "$benchmark_path/linux"
+	pack_contents "$srcdir/linux-${kernel_ver}/." "$benchmark_path/linux"
 
 	# copy the original file instead of link, so don't use -a option
 	# $ ls -lrt $srcdir

--- a/programs/lmbench3/run
+++ b/programs/lmbench3/run
@@ -139,7 +139,8 @@ run_lmbench3_development()
 	local LMBENCH_PATH="$(find bin/ -maxdepth 2 -name lmbench)"
 
 	# shellcheck disable=SC2016
-	sed -i '/lat_pagefault -P $SYNC_MAX $FILE/i [[ -f $FILE ]] || dd if=/dev/zero of=$FILE count=1 bs=1G' $LMBENCH_PATH
+	grep -q 'dd if=/dev/zero of=$FILE count=1 bs=1G' $LMBENCH_PATH ||
+	sed -i '/lat_pagefault -P $SYNC_MAX $FILE/i [ -f $FILE ] || dd if=/dev/zero of=$FILE count=1 bs=1G' $LMBENCH_PATH
 	log_eval "
 	(
 		echo $nr_threads


### PR DESCRIPTION
The 2 commits in this series addresses two different issues introduced by these two commits b072fec987d0 ("programs: refactor to use bash") and  a8a700f4998f ("programs/kernbench/pkg/PKGBUILD: resolve missing benchmark path").

**Before the patch on kernbench and lmbench3**
-------------------------------------------------------
**kernbench o/p:**
2026-06-15 09:46:18 +0000 WARN -- skip non-executable /home/suneeth/lkp-tests/programs/cpuid/one-shot-monitor
2026-06-15 09:46:18 +0000 WARN -- skip non-executable /home/suneeth/lkp-tests/programs/hwinfo/one-shot-monitor
2026-06-15 09:46:18 +0000 WARN -- skip non-executable /home/suneeth/lkp-tests/programs/inxi/one-shot-monitor
2026-06-15 09:46:19 cd /lkp/benchmarks/kernbench
No kernel source found; exiting
2026-06-15 09:46:24 +0000 WARN -- skip non-executable /home/suneeth/lkp-tests/programs/cpuid/one-shot-monitor
2026-06-15 09:46:24 +0000 WARN -- skip non-executable /home/suneeth/lkp-tests/programs/hwinfo/one-shot-monitor
2026-06-15 09:46:24 +0000 WARN -- skip non-executable /home/suneeth/lkp-tests/programs/inxi/one-shot-monitor

**lmbench3 o/p:**
./lmbench: 201: [[: not found
1+0 records in
1+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 2.77183 s, 387 MB/s
./lmbench: 202: [[: not found
1+0 records in
1+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 3.37569 s, 318 MB/s
Pagefaults on /var/tmp/XXX: 0.0138 microseconds

**After the patch on kernbench and lmbench3**
-----------------------------------------------------
**kernbench o/p:**
2026-06-15 10:01:24 +0000 WARN -- skip non-executable /home/suneeth/lkp-tests/programs/cpuid/one-shot-monitor
2026-06-15 10:01:24 +0000 WARN -- skip non-executable /home/suneeth/lkp-tests/programs/hwinfo/one-shot-monitor
2026-06-15 10:01:24 +0000 WARN -- skip non-executable /home/suneeth/lkp-tests/programs/inxi/one-shot-monitor
2026-06-15 10:01:25 cd /lkp/benchmarks/kernbench
256 cpus found
Cleaning source tree...
No old config found, using allnoconfig
Making mrproper
Making allnoconfig...
Kernel 7.0.3-03e81f004d7e-9d0263b744
Performing 1 runs of
make -j 128

All data logged to kernbench.log
Optimal load -j 128 run number 1...
Average Optimal load -j 128 Run (std deviation):
Elapsed Time 8.630000
User Time 209.560000
System Time 133.420000
Percent CPU 3971.000000
Context Switches 5309.000000
Sleeps 28597.000000

2026-06-15 10:01:58 +0000 WARN -- skip non-executable /home/suneeth/lkp-tests/programs/cpuid/one-shot-monitor
2026-06-15 10:01:58 +0000 WARN -- skip non-executable /home/suneeth/lkp-tests/programs/hwinfo/one-shot-monitor
2026-06-15 10:01:58 +0000 WARN -- skip non-executable /home/suneeth/lkp-tests/programs/inxi/one-shot-monitor

**lmbench3 o/p:**
1+0 records in
1+0 records out
1073741824 bytes (1.1 GB, 1.0 GiB) copied, 1.88753 s, 569 MB/s
Pagefaults on /var/tmp/XXX: 0.0143 microseconds