### PR TITLE
Enable support for Ubuntu-26.04 (Resolute Raccoon)

### DIFF
--- a/distro/adaptation/ubuntu/26.04
+++ b/distro/adaptation/ubuntu/26.04
@@ -1,0 +1,49 @@
+# resolute
+crda:
+cython:
+dh-systemd: debhelper
+exfat-utils: exfatprogs
+freeglut:
+fuse: fuse3
+lib32gcc-dev: lib32gcc-15-dev
+libaio:
+libarchive: libarchive13t64
+libasound2:
+libcurl:
+libdw1: libdw1t64
+libevent-openssl: libevent-openssl-2.1-7t64
+libevent: libevent-2.1-7t64
+libglut3: libglut3.12
+libgsl: libgsl28
+libiniparser:
+libipsec-mb: libipsec-mb2
+libjson: libjson-c5
+libldap: libldap2
+libncurses: libncurses6
+libnfs: libnfs14
+libntfs: libntfs-3g89t64
+libperl5:
+libpolly-dev: libpolly-18-dev
+libprocps-dev:
+libprocps:
+libpython2:
+libpython3: libpython3.14
+libreadline5: readline-common
+libssl: libssl3t64
+libtirpc: libtirpc-common
+libunwind: libunwind-18
+liburcu:
+liburing: liburing2
+libx32gcc-dev: libx32gcc-15-dev
+libx32gcc1: libx32gcc-s1
+netpipe-lam:
+netpipe-mpich2:
+netpipe-openmpi:
+netpipe-pvm:
+netpipe-tcp:
+perl-modules-5: perl-modules-5.40
+python3-crypto: python3-pycryptodome
+python3-gobject:
+python3-tox: tox
+python: python-is-python3
+qt5-default: qtbase5-dev


### PR DESCRIPTION
This patch fix failure of microbenchmarks installation such as kernbench on Ubuntu-26.04 systems. Also as a little extra effort enables support for Ubuntu-26.04 in the lkp-tests as a whole.

Before the patch:
-------------------
Note, selecting 'libelf1t64' instead of 'libelf1'
E: Unable to locate package libssl1.1
E: Couldn't find any package by glob 'libssl1.1'
E: Couldn't find any package by regex 'libssl1.1'
Cannot install some packages of kernbench depends

After the patch:
-----------------
kernbench::
x86_64
==> Making package: kernbench 0.50-1 (Fri Jul 17 10:08:57 AM UTC 2026)
==> Checking runtime dependencies...
==> Checking buildtime dependencies...
==> Retrieving sources...
  -> Source is http://ck.kolivas.org/apps/kernbench/kernbench-0.50/kernbench
  -> Downloading kernbench...
  % Total    % Received % Xferd  Average Speed  Time    Time    Time   Current
                                 Dload  Upload  Total   Spent   Left   Speed
100   5706 100   5706   0      0   6148      0                              0
  -> Source is https://www.kernel.org/pub/linux/kernel/v5.x/linux-5.9.tar.xz
  -> Downloading linux-5.9.tar.xz...
  % Total    % Received % Xferd  Average Speed  Time    Time    Time   Current
                                 Dload  Upload  Total   Spent   Left   Speed
100 110.1M 100 110.1M   0      0 983.4k      0   01:54   01:54          1.13M
==> WARNING: Skipping verification of source file PGP signatures.
==> Validating source files with md5sums...
    kernbench ... Skipped
    linux-5.9.tar.xz ... Skipped
==> Extracting sources...
  -> Source is http://ck.kolivas.org/apps/kernbench/kernbench-0.50/kernbench
  -> Source is https://www.kernel.org/pub/linux/kernel/v5.x/linux-5.9.tar.xz
  -> Extracting linux-5.9.tar.xz with bsdtar
==> Starting prepare()...
==> Starting patch_source()...
_patch_source: PWD=/home/suneeth/lkp-tests/tmp-pkg/kernbench/src, startdir=/home/suneeth/lkp-tests/programs/kernbench/pkg, pkgname=kernbench, srcdir=/home/suneeth/lkp-tests/tmp-pkg/kernbench/src
==> Starting build()...
==> Entering fakeroot environment...
x86_64
==> Starting package()...
2026-07-17 10:10:57 cp -a /home/suneeth/lkp-tests/tmp-pkg/kernbench/src/linux-5.9/. /home/suneeth/lkp-tests/tmp-pkg/kernbench/pkg/kernbench/lkp/benchmarks/kernbench/linux
2026-07-17 10:11:01 cp -a -L /home/suneeth/lkp-tests/tmp-pkg/kernbench/src/kernbench /home/suneeth/lkp-tests/tmp-pkg/kernbench/pkg/kernbench/lkp/benchmarks/kernbench
==> Tidying install...
  -> Purging unwanted files...
  -> Removing libtool files...
  -> Removing static library files...
  -> Compressing man and info pages...
  -> Stripping unneeded symbols from binaries and libraries...
==> Creating package "kernbench"...
  -> Generating .MTREE file...
  -> Compressing package...
==> Leaving fakeroot environment.
==> Finished making: kernbench 0.50-1 (Fri Jul 17 10:14:08 AM UTC 2026)
==> Installing package kernbench with /home/suneeth/lkp-tests/sbin/pacman-LKP -U...
dpkg-deb: building package 'kernbench-lkp' in 'kernbench-lkp.deb'.
(Reading database… 267801 files and directories currently installed.)
Preparing to unpack kernbench-lkp.deb…
Unpacking kernbench-lkp (2026-07-17) over (2026-07-14)…
Setting up kernbench-lkp (2026-07-17)…
install **succeed**